### PR TITLE
Backfill top-200 players + wire head-to-head into Compare Players

### DIFF
--- a/backend/app/routes/player_routes.py
+++ b/backend/app/routes/player_routes.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
-from app.services.data_service import compare_players, get_player_snapshot
+from app.services.data_service import compare_players_with_h2h, get_player_snapshot
 from app.services.llm_service import (
     build_compare_prompt,
     build_player_prompt,
@@ -28,7 +28,9 @@ def get_player_report(name: str) -> dict:
 
 @router.post("/compare")
 def get_compare_report(payload: CompareRequest) -> dict:
-    snapshots = compare_players(payload.player_names)
+    result = compare_players_with_h2h(payload.player_names)
+    snapshots = result["snapshots"]
+    h2h = result["h2h"]
 
     if len(snapshots) < 2:
         found_players = {s["player"]["name"] for s in snapshots}
@@ -41,11 +43,12 @@ def get_compare_report(payload: CompareRequest) -> dict:
             },
         )
 
-    prompt = build_compare_prompt(snapshots)
+    prompt = build_compare_prompt(snapshots, h2h)
     report_result = generate_report(prompt)
 
     return {
         "players": [s["player"] for s in snapshots],
         "snapshots": snapshots,
+        "h2h": h2h,
         **report_result,
     }

--- a/backend/app/services/atp_api_service.py
+++ b/backend/app/services/atp_api_service.py
@@ -1,13 +1,13 @@
 """
 Service for interacting with the ATP Tennis API.
 
-Provides functionality to fetch player profiles and extract profile information
-from the external ATP API.
+Provides functionality to fetch player profiles, match histories, and extract
+profile information from the external ATP API.
 """
 
 import time
 from typing import Optional
-from datetime import datetime
+from datetime import date, datetime
 
 import requests
 
@@ -50,6 +50,303 @@ def fetch_player_profile(player_id: int, delay: float = 1.5) -> Optional[dict]:
         return None
 
 
+def fetch_player_matches(
+    player_id: int,
+    page_size: int = 500,
+    page_no: int = 1,
+    delay: float = 1.5,
+    max_retries: int = 5,
+) -> list[dict]:
+    """
+    Fetch past matches for a player from ATP API.
+
+    Includes exponential backoff retry logic for 429 (Too Many Requests) errors.
+
+    Args:
+        player_id: The ATP player ID to fetch matches for
+        page_size: Number of matches per page (max 500)
+        page_no: Page number to fetch
+        delay: Delay in seconds before making the request (for rate limiting)
+        max_retries: Maximum number of retries on 429 errors
+
+    Returns:
+        List of match dictionaries, or empty list if request fails
+    """
+    time.sleep(delay)
+
+    settings = get_settings()
+
+    if not settings.tennis_api_key:
+        raise ValueError("TENNIS_API_KEY not configured in environment")
+
+    url = (
+        f"https://{settings.tennis_api_host}/tennis/v2/atp/player/"
+        f"past-matches/{player_id}/?pageSize={page_size}&pageNo={page_no}"
+    )
+
+    headers = {
+        "Content-Type": "application/json",
+        "x-rapidapi-host": settings.tennis_api_host,
+        "x-rapidapi-key": settings.tennis_api_key,
+    }
+
+    for attempt in range(max_retries + 1):
+        try:
+            response = requests.get(url, headers=headers, timeout=15)
+            response.raise_for_status()
+            data = response.json()
+            return data.get("data", [])
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 429 and attempt < max_retries:
+                backoff = delay * (2 ** (attempt + 1))  # 3s, 6s, 12s, 24s, 48s
+                print(
+                    f"  ⏳ Rate limited (429) for player {player_id}, "
+                    f"retrying in {backoff:.0f}s (attempt {attempt + 1}/{max_retries})..."
+                )
+                time.sleep(backoff)
+                continue
+            print(f"Error fetching matches for player {player_id}: {e}")
+            return []
+        except requests.exceptions.RequestException as e:
+            print(f"Error fetching matches for player {player_id}: {e}")
+            return []
+
+
+def fetch_tournament_info(
+    tournament_id: int,
+    delay: float = 1.5,
+    max_retries: int = 5,
+) -> Optional[dict]:
+    """
+    Fetch tournament metadata (name, court/surface, country, date, tier) from
+    the ATP API. Returns the parsed `data` object or None on failure.
+
+    Endpoint: /tennis/v2/atp/tournament/info/{id}/
+    Sample response shape:
+        {"data": {"id": 21323, "name": "Barcelona Open ...",
+                  "court": {"id": 2, "name": "Clay"},
+                  "tier": "ATP 500",
+                  "date": "2026-04-13T00:00:00.000Z",
+                  "coutry": {"acronym": "ESP", "name": "Spain"}}}
+    """
+    settings = get_settings()
+    if not settings.tennis_api_key:
+        raise ValueError("TENNIS_API_KEY not configured in environment")
+
+    url = f"https://{settings.tennis_api_host}/tennis/v2/atp/tournament/info/{tournament_id}/"
+    headers = {
+        "Content-Type": "application/json",
+        "x-rapidapi-host": settings.tennis_api_host,
+        "x-rapidapi-key": settings.tennis_api_key,
+    }
+
+    time.sleep(delay)
+    for attempt in range(max_retries + 1):
+        try:
+            response = requests.get(url, headers=headers, timeout=15)
+            if response.status_code == 404:
+                return None
+            response.raise_for_status()
+            payload = response.json()
+            return payload.get("data") if isinstance(payload, dict) else None
+        except requests.exceptions.HTTPError as e:
+            if response.status_code == 429 and attempt < max_retries:
+                backoff = delay * (2 ** (attempt + 1))
+                print(
+                    f"  ⏳ Rate limited (429) on tournament {tournament_id}, "
+                    f"retrying in {backoff:.0f}s (attempt {attempt + 1}/{max_retries})..."
+                )
+                time.sleep(backoff)
+                continue
+            print(f"  Tournament fetch failed for {tournament_id}: {e}")
+            return None
+        except requests.exceptions.RequestException as e:
+            print(f"  Tournament fetch error for {tournament_id}: {e}")
+            return None
+    return None
+
+
+def fetch_atp_rankings(
+    top_n: int = 200,
+    delay: float = 1.5,
+    max_retries: int = 5,
+    debug_log_first_response: bool = False,
+) -> list[dict]:
+    """
+    Fetch the current ATP singles rankings from the API.
+
+    Tries a sequence of likely endpoint paths (RapidAPI tennis hosts vary in
+    their ranking-endpoint shape) and returns normalized entries:
+        [{"rank": int, "player_id": int, "first_name": str,
+          "last_name": str, "full_name": str, "country": str | None}, ...]
+
+    Args:
+        top_n: Maximum number of entries to return (truncates after fetching).
+        delay: Seconds to wait before the request (rate limiting).
+        max_retries: Retries on 429.
+        debug_log_first_response: If True, prints the raw JSON of the first
+            successful response (used to discover field names on initial run).
+
+    Returns:
+        List of normalized ranking dicts (may be shorter than top_n if API
+        returns fewer entries). Empty list if every candidate path fails.
+    """
+    settings = get_settings()
+    if not settings.tennis_api_key:
+        raise ValueError("TENNIS_API_KEY not configured in environment")
+
+    headers = {
+        "Content-Type": "application/json",
+        "x-rapidapi-host": settings.tennis_api_host,
+        "x-rapidapi-key": settings.tennis_api_key,
+    }
+
+    # The ranking endpoint returns ~11 entries by default; pageSize/pageNo
+    # extends it. Confirmed to return 201 entries at pageSize=200.
+    qs = f"?pageSize={top_n}&pageNo=1"
+    # Candidate paths — try in order of plausibility. The first one that
+    # returns 200 with a parseable list wins.
+    candidates = [
+        f"https://{settings.tennis_api_host}/tennis/v2/atp/ranking/singles/{qs}",
+        f"https://{settings.tennis_api_host}/tennis/v2/atp/rankings/singles/{qs}",
+        f"https://{settings.tennis_api_host}/tennis/v2/atp/ranking/{qs}",
+        f"https://{settings.tennis_api_host}/tennis/v2/atp/rankings/{qs}",
+    ]
+
+    raw = None
+    used_url = None
+    for url in candidates:
+        time.sleep(delay)
+        for attempt in range(max_retries + 1):
+            try:
+                response = requests.get(url, headers=headers, timeout=15)
+                if response.status_code == 404:
+                    print(f"  Rankings endpoint not found at {url} — trying next candidate")
+                    break  # try next candidate
+                response.raise_for_status()
+                raw = response.json()
+                used_url = url
+                break
+            except requests.exceptions.HTTPError as e:
+                if response.status_code == 429 and attempt < max_retries:
+                    backoff = delay * (2 ** (attempt + 1))
+                    print(
+                        f"  ⏳ Rate limited (429) on rankings, "
+                        f"retrying in {backoff:.0f}s (attempt {attempt + 1}/{max_retries})..."
+                    )
+                    time.sleep(backoff)
+                    continue
+                print(f"  Rankings fetch failed at {url}: {e}")
+                break
+            except requests.exceptions.RequestException as e:
+                print(f"  Rankings fetch error at {url}: {e}")
+                break
+        if raw is not None:
+            break
+
+    if raw is None:
+        print("  ✗ All rankings endpoint candidates failed.")
+        return []
+
+    print(f"  ✓ Rankings fetched from {used_url}")
+    if debug_log_first_response:
+        # Print just the first entry for shape inspection
+        if isinstance(raw, dict) and "data" in raw:
+            sample = raw["data"][:1] if isinstance(raw["data"], list) else raw["data"]
+        elif isinstance(raw, list):
+            sample = raw[:1]
+        else:
+            sample = raw
+        print(f"  [debug] First ranking entry: {sample!r}")
+
+    return _normalize_rankings_response(raw, top_n)
+
+
+def _normalize_rankings_response(raw, top_n: int) -> list[dict]:
+    """
+    Normalize the raw rankings response into a uniform list of dicts.
+
+    Handles common shape variants:
+      - {"data": [{...}, ...]}
+      - [{...}, ...]
+      - {"rankings": [{...}, ...]}
+    """
+    if isinstance(raw, dict):
+        entries = raw.get("data") or raw.get("rankings") or raw.get("items") or []
+    elif isinstance(raw, list):
+        entries = raw
+    else:
+        entries = []
+
+    if not isinstance(entries, list):
+        print(f"  Rankings entries not a list (got {type(entries).__name__}); returning empty.")
+        return []
+
+    normalized: list[dict] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+
+        rank = entry.get("rank") or entry.get("ranking") or entry.get("position")
+        try:
+            rank = int(rank) if rank is not None else None
+        except (TypeError, ValueError):
+            rank = None
+        if rank is None or rank > top_n:
+            continue
+
+        # Player container can be inline or nested under "player"
+        player = entry.get("player") if isinstance(entry.get("player"), dict) else entry
+
+        pid = (
+            player.get("id")
+            or player.get("playerId")
+            or player.get("player_id")
+            or entry.get("playerId")
+            or entry.get("player_id")
+        )
+        try:
+            pid = int(pid) if pid is not None else None
+        except (TypeError, ValueError):
+            pid = None
+        if pid is None:
+            continue
+
+        first_name = player.get("firstName") or player.get("first_name") or ""
+        last_name = player.get("lastName") or player.get("last_name") or ""
+        full_name = (
+            player.get("fullName")
+            or player.get("full_name")
+            or player.get("name")
+            or f"{first_name} {last_name}".strip()
+        )
+
+        # If we only got full_name, split on first space
+        if (not first_name or not last_name) and full_name:
+            parts = full_name.split(" ", 1)
+            first_name = first_name or parts[0]
+            last_name = last_name or (parts[1] if len(parts) > 1 else "")
+
+        country = (
+            player.get("countryAcr")
+            or player.get("country")
+            or player.get("countryCode")
+            or entry.get("countryAcr")
+        )
+
+        normalized.append({
+            "rank": rank,
+            "player_id": pid,
+            "first_name": first_name,
+            "last_name": last_name,
+            "full_name": full_name or f"{first_name} {last_name}".strip(),
+            "country": country,
+        })
+
+    normalized.sort(key=lambda r: r["rank"])
+    return normalized[:top_n]
+
+
 def extract_player_data_from_profile(profile: Optional[dict]) -> dict:
     """
     Extract player information from ATP API profile response.
@@ -59,7 +356,7 @@ def extract_player_data_from_profile(profile: Optional[dict]) -> dict:
 
     Returns:
         Dictionary with keys: coach, height_cm, weight_kg, handedness,
-                              backhand_type, pro_since
+                              backhand_type, pro_since, birthdate
     """
     result = {
         "coach": None,
@@ -68,6 +365,7 @@ def extract_player_data_from_profile(profile: Optional[dict]) -> dict:
         "handedness": None,
         "backhand_type": None,
         "pro_since": None,
+        "birthdate": None,
     }
 
     if not profile or "data" not in profile:
@@ -124,4 +422,36 @@ def extract_player_data_from_profile(profile: Optional[dict]) -> dict:
         except (ValueError, TypeError):
             pass
 
+    # Extract birthdate. API may return it under several keys; try common ones.
+    raw_dob = (
+        info.get("dateOfBirth")
+        or info.get("dob")
+        or info.get("birthdate")
+        or info.get("birthDate")
+    )
+    if raw_dob:
+        result["birthdate"] = _parse_birthdate(raw_dob)
+
     return result
+
+
+def _parse_birthdate(raw) -> Optional[date]:
+    """Parse a birthdate from common string/dict shapes returned by the API."""
+    if isinstance(raw, dict):
+        # Some APIs return {"year": 2003, "month": 5, "day": 5}
+        try:
+            return date(int(raw["year"]), int(raw["month"]), int(raw["day"]))
+        except (KeyError, TypeError, ValueError):
+            return None
+    if not isinstance(raw, str):
+        return None
+    s = raw.strip()
+    if not s:
+        return None
+    # Try ISO first, then a few common alternates
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%d-%m-%Y", "%d/%m/%Y", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(s[:10], fmt).date()
+        except ValueError:
+            continue
+    return None

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -4,7 +4,7 @@ from collections import Counter
 from contextlib import contextmanager
 from typing import Iterator
 
-from sqlalchemy import or_, select
+from sqlalchemy import and_, or_, select
 from sqlalchemy.orm import Session
 
 from app.db import SessionLocal
@@ -218,3 +218,125 @@ def compare_players(player_names: list[str]) -> list[dict]:
         if snapshot:
             snapshots.append(snapshot)
     return snapshots
+
+
+# ── Head-to-Head ────────────────────────────────────────────────────────────
+
+MAX_H2H_MEETINGS = 10
+
+
+def compute_h2h(session: Session, p1_id: int, p2_id: int) -> dict:
+    """
+    Compute the head-to-head record between two players from the matches table.
+
+    Returns:
+        {
+          "player1_id": int,
+          "player2_id": int,
+          "record": {"player1_wins": int, "player2_wins": int,
+                     "total_meetings": int, "decided": int},
+          "surface_split": {
+            "<surface>": {"player1_wins": int, "player2_wins": int, "matches": int}
+          },
+          "meetings": [
+            {"match_id": int, "date": str|None, "tournament": str|None,
+             "round": str|None, "surface": str|None,
+             "winner_id": int|None, "winner_name": str|None,
+             "score": str|None}
+          ]
+        }
+    """
+    matches = list(
+        session.scalars(
+            select(Match)
+            .where(
+                or_(
+                    and_(Match.player1_id == p1_id, Match.player2_id == p2_id),
+                    and_(Match.player1_id == p2_id, Match.player2_id == p1_id),
+                )
+            )
+            .order_by(Match.date.desc().nulls_last(), Match.id.desc())
+        )
+    )
+
+    p1_wins = 0
+    p2_wins = 0
+    decided = 0
+    surface_split: dict[str, dict[str, int]] = {}
+    meetings: list[dict] = []
+
+    for m in matches:
+        if m.winner_id is not None:
+            decided += 1
+            if m.winner_id == p1_id:
+                p1_wins += 1
+            elif m.winner_id == p2_id:
+                p2_wins += 1
+
+        if m.surface:
+            bucket = surface_split.setdefault(
+                m.surface,
+                {"player1_wins": 0, "player2_wins": 0, "matches": 0},
+            )
+            bucket["matches"] += 1
+            if m.winner_id == p1_id:
+                bucket["player1_wins"] += 1
+            elif m.winner_id == p2_id:
+                bucket["player2_wins"] += 1
+
+        if len(meetings) < MAX_H2H_MEETINGS:
+            winner_name: str | None = None
+            if m.winner_id is not None:
+                if m.player1 and m.winner_id == m.player1_id:
+                    winner_name = m.player1.full_name
+                elif m.player2 and m.winner_id == m.player2_id:
+                    winner_name = m.player2.full_name
+            meetings.append({
+                "match_id": m.id,
+                "date": m.date.isoformat() if m.date else None,
+                "tournament": m.tournament.name if m.tournament else None,
+                "round": m.round,
+                "surface": m.surface,
+                "winner_id": m.winner_id,
+                "winner_name": winner_name,
+                "score": m.score,
+            })
+
+    return {
+        "player1_id": p1_id,
+        "player2_id": p2_id,
+        "record": {
+            "player1_wins": p1_wins,
+            "player2_wins": p2_wins,
+            "total_meetings": len(matches),
+            "decided": decided,
+        },
+        "surface_split": surface_split,
+        "meetings": meetings,
+    }
+
+
+def compare_players_with_h2h(player_names: list[str]) -> dict:
+    """
+    Build snapshots for the requested players and, when exactly two valid
+    players are resolved, also compute their head-to-head record.
+
+    Returns:
+        {"snapshots": [...], "h2h": dict | None}
+    """
+    with get_session() as session:
+        snapshots: list[dict] = []
+        for name in player_names:
+            snap = _get_player_snapshot_with_session(session, name)
+            if snap:
+                snapshots.append(snap)
+
+        h2h: dict | None = None
+        if len(snapshots) == 2:
+            h2h = compute_h2h(
+                session,
+                snapshots[0]["player"]["id"],
+                snapshots[1]["player"]["id"],
+            )
+
+        return {"snapshots": snapshots, "h2h": h2h}

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -61,7 +61,7 @@ def build_player_prompt(snapshot: dict) -> str:
     return "\n".join(lines)
 
 
-def build_compare_prompt(snapshots: list[dict]) -> str:
+def build_compare_prompt(snapshots: list[dict], h2h: dict | None = None) -> str:
     sections = []
     for s in snapshots:
         stats = s["stats"]
@@ -82,13 +82,16 @@ def build_compare_prompt(snapshots: list[dict]) -> str:
         )
 
     players = "\n".join(sections)
+    h2h_block = _format_h2h_for_prompt(snapshots, h2h)
 
     return (
         "You are an elite tennis analyst. Compare the following two players and provide a detailed"
         " head-to-head analysis with a match prediction.\n\n"
         f"Players:\n{players}\n\n"
+        f"{h2h_block}\n"
         "IMPORTANT: Your prediction should NOT blindly favor the historically better player. "
-        "Prioritize recent form, current physical condition/age, and surface context.\n\n"
+        "Prioritize recent form, current physical condition/age, and surface context. "
+        "When you cite the head-to-head, use ONLY the numbers above — do not invent meetings.\n\n"
         "Output the following sections using markdown headings:\n"
         "## Head-to-Head Summary\n"
         "## Recent Form\n"
@@ -98,6 +101,54 @@ def build_compare_prompt(snapshots: list[dict]) -> str:
         "In the Prediction section, clearly state the predicted winner and explain why with a "
         "confidence assessment."
     )
+
+
+def _format_h2h_for_prompt(snapshots: list[dict], h2h: dict | None) -> str:
+    """Render the head-to-head record as a compact prompt block."""
+    if not h2h or len(snapshots) < 2:
+        return "Head-to-head record: not available.\n"
+
+    p1_name = snapshots[0]["player"]["name"]
+    p2_name = snapshots[1]["player"]["name"]
+    rec = h2h.get("record", {})
+    total = rec.get("total_meetings", 0)
+    p1_wins = rec.get("player1_wins", 0)
+    p2_wins = rec.get("player2_wins", 0)
+
+    if total == 0:
+        return f"Head-to-head record: no prior meetings between {p1_name} and {p2_name}.\n"
+
+    # Surface split
+    surface_lines = []
+    for surface, split in (h2h.get("surface_split") or {}).items():
+        surface_lines.append(
+            f"  - {surface}: {p1_name} {split['player1_wins']}-{split['player2_wins']} {p2_name}"
+            f" ({split['matches']} match{'es' if split['matches'] != 1 else ''})"
+        )
+
+    # Last 5 meetings
+    meeting_lines = []
+    for m in (h2h.get("meetings") or [])[:5]:
+        winner = m.get("winner_name") or ("Unknown" if m.get("winner_id") is None else "")
+        date_str = m.get("date") or "date unknown"
+        surface = m.get("surface") or "surface unknown"
+        score = m.get("score") or ""
+        tourn = m.get("tournament") or ""
+        meeting_lines.append(
+            f"  - {date_str} | {tourn} | {surface} | winner: {winner} | score: {score}"
+        )
+
+    parts = [
+        f"Head-to-head record: {p1_name} {p1_wins}-{p2_wins} {p2_name} "
+        f"({total} total meeting{'s' if total != 1 else ''}).",
+    ]
+    if surface_lines:
+        parts.append("Surface split:")
+        parts.extend(surface_lines)
+    if meeting_lines:
+        parts.append("Most recent meetings (newest first):")
+        parts.extend(meeting_lines)
+    return "\n".join(parts) + "\n"
 
 
 def generate_report(prompt: str) -> ReportResult:

--- a/backend/data_ingestion/__init__.py
+++ b/backend/data_ingestion/__init__.py
@@ -1,0 +1,1 @@
+"""Data ingestion module for Tennis Scout Agent."""

--- a/backend/data_ingestion/stats_ingester.py
+++ b/backend/data_ingestion/stats_ingester.py
@@ -1,0 +1,402 @@
+"""
+Production-ready data ingestion for player career statistics.
+
+Fetches all players from the database, calls the ATP stats API for each,
+and upserts the aggregated career stats into the player_stats table.
+
+Key features:
+- Idempotent upserts using ON CONFLICT (player_id, stat_type) DO UPDATE
+- Exponential backoff retry logic for API failures (429, timeout)
+- Rate limiting (1.5s delay between requests)
+- Batch processing to avoid memory overhead
+- Comprehensive logging and error handling
+- Field mapping from API response to database schema
+- Unmapped fields stored in vendor_stats JSONB column
+"""
+
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+logger = logging.getLogger(__name__)
+
+# API Configuration
+API_HOST = "tennis-api-atp-wta-itf.p.rapidapi.com"
+API_BASE_URL = "https://tennis-api-atp-wta-itf.p.rapidapi.com/tennis/v2/atp/h2h"
+REQUEST_TIMEOUT = 15
+RATE_LIMIT_DELAY = 5.0  # seconds between requests (increased further to handle stricter rate limiting)
+MAX_RETRIES = 5
+RETRY_BASE_DELAY = 5  # seconds (exponential backoff: 5, 10, 20, 40, 80)
+
+# Field mapping: API response field -> database column name
+# Only the 8 columns in player_stats table that have direct equivalents
+FIELD_MAPPING_TO_COLUMNS = {
+    "aces": "aces",
+    "doubleFaults": "double_faults",
+    "firstServePercentage": "first_serve_pct",
+    "winningOnFirstServePercentage": "first_serve_win_pct",
+    "winningOnSecondServePercentage": "second_serve_win_pct",
+    "returnPtsWinPercentage": "return_points_won_pct",
+    "breakpointsWonPercentage": "break_points_converted_pct",
+    "tiebreakWon": "tiebreaks_won_pct",  # Note: This is count, will store as percentage in extra_stats
+}
+
+# All 50+ fields from API (including those stored in extra_stats)
+ALL_API_FIELDS = {
+    # Basic match stats
+    "statMatchesPlayed", "matchesWon",
+    
+    # Aces and errors
+    "aces", "doubleFaults", "unforcedErrors", "winners",
+    
+    # First serve stats
+    "firstServe", "firstServeOf", "firstServePercentage",
+    "winningOnFirstServe", "winningOnFirstServeOf", "winningOnFirstServePercentage",
+    "averageFirstServeSpeed",
+    
+    # Second serve stats
+    "winningOnSecondServe", "winningOnSecondServeOf", "winningOnSecondServePercentage",
+    "averageSecondServeSpeed",
+    
+    # Serve speed
+    "fastestServe", "averageFastestServe",
+    
+    # Break point stats
+    "breakPointsConverted", "breakPointsConvertedOf", "breakpointsWonPercentage",
+    
+    # Net approaches
+    "netApproaches", "netApproachesOf",
+    
+    # Return stats
+    "returnPtsWin", "returnPtsWinOf", "returnPtsWinPercentage",
+    
+    # Total points
+    "totalPointsWon",
+    
+    # Sets and games
+    "setsWon", "gamesWon",
+    
+    # Best of three (most common)
+    "bestOfThreeWon", "bestOfThreeCount", "bestOfThreeWonPercentage",
+    
+    # Best of five (Grand Slams)
+    "bestOfFiveWon", "bestOfFiveCount", "bestOfFiveWonPercentage",
+    
+    # First set correlation
+    "firstSetWinMatchWin", "firstSetWinMatchWinPercentage",
+    "firstSetWinMatchLose", "firstSetWinMatchLosePercentage",
+    "firstSetLoseMatchWin", "firstSetLoseMatchWinPercentage",
+    "firstSetWinCount", "firstSetLoseCount",
+    
+    # Deciding set stats
+    "decidingSetWin", "decidingSetCount", "decidingSetWinPercentage",
+    
+    # Tiebreak stats
+    "tiebreakWon", "tiebreakCount", "totalTBWinPercentage",
+    
+    # Tournament breakdown
+    "title", "grandSlam", "masters", "mainTour", "tourFinals", "cups", "futures", "challengers",
+    
+    # Surface breakdown
+    "hard", "clay", "iHard", "grass",
+}
+
+
+def fetch_players(session: Session, limit: Optional[int] = None) -> List[Tuple[int, str]]:
+    """
+    Fetch all players from the database with pagination.
+    
+    Args:
+        session: SQLAlchemy session
+        limit: Optional limit for testing
+        
+    Returns:
+        List of tuples (player_id, player_name)
+    """
+    query = "SELECT id, full_name FROM players ORDER BY id"
+    if limit:
+        query += f" LIMIT {limit}"
+    
+    rows = session.execute(text(query)).fetchall()
+    return [(row[0], row[1]) for row in rows]
+
+
+def fetch_player_stats(
+    player_id: int,
+    api_key: str,
+    retries: int = 0,
+) -> Optional[Dict[str, Any]]:
+    """
+    Fetch player stats from ATP API with exponential backoff retry logic.
+    
+    Args:
+        player_id: ATP player ID
+        api_key: RapidAPI key from environment
+        retries: Current retry attempt count
+        
+    Returns:
+        Parsed JSON response (data.playerStats) or None on failure
+    """
+    if retries > 0:
+        delay = RETRY_BASE_DELAY * (2 ** (retries - 1))
+        logger.warning(f"Retrying player {player_id}, attempt {retries}/{MAX_RETRIES}, waiting {delay}s...")
+        time.sleep(delay)
+    
+    headers = {
+        "Content-Type": "application/json",
+        "x-rapidapi-host": API_HOST,
+        "x-rapidapi-key": api_key,
+    }
+    
+    url = f"{API_BASE_URL}/vs-all-stats/{player_id}/"
+    
+    try:
+        response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
+        
+        # Handle rate limiting
+        if response.status_code == 429:
+            if retries < MAX_RETRIES:
+                return fetch_player_stats(player_id, api_key, retries + 1)
+            else:
+                logger.error(f"Player {player_id}: Rate limited after {MAX_RETRIES} retries")
+                return None
+        
+        response.raise_for_status()
+        
+        data = response.json()
+        player_stats = data.get("data", {}).get("playerStats")
+        
+        if not player_stats:
+            logger.warning(f"Player {player_id}: No playerStats in response")
+            return None
+        
+        return player_stats
+        
+    except requests.exceptions.Timeout:
+        if retries < MAX_RETRIES:
+            logger.warning(f"Player {player_id}: Request timeout, retrying...")
+            return fetch_player_stats(player_id, api_key, retries + 1)
+        else:
+            logger.error(f"Player {player_id}: Timeout after {MAX_RETRIES} retries")
+            return None
+            
+    except requests.exceptions.RequestException as e:
+        if retries < MAX_RETRIES and isinstance(e, requests.exceptions.ConnectionError):
+            logger.warning(f"Player {player_id}: Connection error, retrying...")
+            return fetch_player_stats(player_id, api_key, retries + 1)
+        else:
+            logger.error(f"Player {player_id}: API request failed: {e}")
+            return None
+
+
+def transform_response(api_response: Dict[str, Any], player_id: int) -> Dict[str, Any]:
+    """
+    Transform API response into database schema format.
+    
+    Maps:
+    - Known API fields to the 8 main player_stats columns
+    - All 50+ stats fields to extra_stats JSONB for full preservation
+    - Sets period='career' for all rows
+    - Handles missing/null fields gracefully
+    
+    Args:
+        api_response: playerStats object from API
+        player_id: ATP player ID
+        
+    Returns:
+        Dictionary keyed by database column names with values
+    """
+    transformed = {
+        "player_id": player_id,
+        "period": "career",  # All stats are career aggregates
+        "match_id": None,  # No specific match, aggregate stats
+        "surface": None,  # No surface filter in this aggregation
+    }
+    
+    # Map the 8 main stat columns
+    for api_field, db_column in FIELD_MAPPING_TO_COLUMNS.items():
+        value = api_response.get(api_field)
+        
+        if value is None or value == "":
+            transformed[db_column] = None
+        else:
+            try:
+                # Convert to appropriate numeric type
+                if isinstance(value, str):
+                    if "." in str(value):
+                        transformed[db_column] = float(value)
+                    else:
+                        transformed[db_column] = int(value)
+                else:
+                    transformed[db_column] = value
+            except (ValueError, TypeError):
+                transformed[db_column] = None
+    
+    # Store all raw API stats in extra_stats JSONB for full preservation
+    extra_stats = {}
+    for api_field in ALL_API_FIELDS:
+        value = api_response.get(api_field)
+        if value is not None and value != "":
+            try:
+                # Convert string numbers to actual numbers
+                if isinstance(value, str):
+                    if "." in str(value):
+                        extra_stats[api_field] = float(value)
+                    else:
+                        extra_stats[api_field] = int(value)
+                else:
+                    extra_stats[api_field] = value
+            except (ValueError, TypeError):
+                extra_stats[api_field] = value
+    
+    transformed["extra_stats"] = json.dumps(extra_stats) if extra_stats else None
+    
+    return transformed
+
+
+def upsert_player_stats(session: Session, batch_data: List[Dict[str, Any]]) -> Tuple[int, List[str]]:
+    """
+    Batch upsert player stats.
+    
+    Since the table doesn't have a unique constraint on (player_id, period),
+    we delete existing 'career' stats for these players, then insert new ones.
+    This ensures idempotency: re-running the script won't create duplicates.
+    
+    Args:
+        session: SQLAlchemy session
+        batch_data: List of dictionaries with transformed player stats
+        
+    Returns:
+        Tuple of (rows_affected, list of errors)
+    """
+    if not batch_data:
+        return 0, []
+    
+    errors = []
+    
+    try:
+        # Extract player_ids to delete existing career stats
+        player_ids = [row["player_id"] for row in batch_data]
+        player_ids_str = ", ".join(str(pid) for pid in player_ids)
+        
+        # Delete existing 'career' stats for these players (idempotency)
+        delete_sql = f"""
+            DELETE FROM player_stats
+            WHERE player_id IN ({player_ids_str})
+            AND period = 'career'
+        """
+        session.execute(text(delete_sql))
+        
+        # Get column names from first row
+        columns = list(batch_data[0].keys())
+        columns_str = ", ".join(columns)
+        placeholders = ", ".join([f":{col}" for col in columns])
+        
+        # Insert new stats
+        insert_sql = f"""
+            INSERT INTO player_stats ({columns_str})
+            VALUES ({placeholders})
+        """
+        
+        result = session.execute(text(insert_sql), [dict(row) for row in batch_data])
+        session.commit()
+        return result.rowcount, errors
+    except Exception as e:
+        session.rollback()
+        errors.append(str(e))
+        logger.error(f"Upsert batch failed: {e}")
+        return 0, errors
+
+
+def ingest_player_stats(
+    session: Session,
+    api_key: str,
+    batch_size: int = 50,
+    player_ids: Optional[List[int]] = None,
+    dry_run: bool = False,
+) -> Dict[str, int]:
+    """
+    Main ingestion orchestration function.
+    
+    Args:
+        session: SQLAlchemy session
+        api_key: RapidAPI key
+        batch_size: Number of players to process before batch upsert
+        player_ids: Optional list of specific player IDs to ingest (for testing)
+        dry_run: If True, only fetch and transform, don't insert
+        
+    Returns:
+        Dictionary with success_count, failure_count, skipped_count
+    """
+    # Fetch players
+    if player_ids:
+        players = [(pid, f"Player {pid}") for pid in player_ids]
+        logger.info(f"Ingesting {len(players)} specific players (dry_run={dry_run})")
+    else:
+        players = fetch_players(session)
+        logger.info(f"Ingesting {len(players)} total players (dry_run={dry_run})")
+    
+    success_count = 0
+    failure_count = 0
+    skipped_count = 0
+    batch = []
+    
+    for idx, (player_id, player_name) in enumerate(players, 1):
+        # Fetch stats from API
+        api_response = fetch_player_stats(player_id, api_key)
+        
+        if api_response is None:
+            failure_count += 1
+            continue
+        
+        # Transform response
+        try:
+            transformed = transform_response(api_response, player_id)
+            batch.append(transformed)
+        except Exception as e:
+            logger.error(f"Transform failed for player {player_id}: {e}")
+            failure_count += 1
+            continue
+        
+        # Log progress every batch_size players
+        if idx % batch_size == 0 or idx == len(players):
+            logger.info(f"Processed {idx}/{len(players)} players")
+        
+        # Upsert batch when full
+        if len(batch) >= batch_size:
+            if not dry_run:
+                inserted, errors = upsert_player_stats(session, batch)
+                success_count += inserted
+                if errors:
+                    failure_count += len(errors)
+            else:
+                success_count += len(batch)
+                logger.debug(f"[DRY RUN] Would upsert {len(batch)} records")
+            
+            batch = []
+        
+        # Rate limiting between requests
+        time.sleep(RATE_LIMIT_DELAY)
+    
+    # Upsert final batch
+    if batch:
+        if not dry_run:
+            inserted, errors = upsert_player_stats(session, batch)
+            success_count += inserted
+            if errors:
+                failure_count += len(errors)
+        else:
+            success_count += len(batch)
+            logger.debug(f"[DRY RUN] Would upsert final {len(batch)} records")
+    
+    return {
+        "success_count": success_count,
+        "failure_count": failure_count,
+        "skipped_count": skipped_count,
+        "total_players": len(players),
+    }

--- a/backend/scripts/__init__.py
+++ b/backend/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Scripts module for Tennis Scout Agent."""

--- a/backend/scripts/full_backfill.py
+++ b/backend/scripts/full_backfill.py
@@ -1,0 +1,237 @@
+"""
+End-to-end backfill orchestrator for the tennis_scout database.
+
+Runs four phases sequentially, each idempotent and skippable:
+
+  1. Sync top-N ATP rankings (extends/refreshes the players table)
+  2. Profile data (coach, height, weight, handedness, backhand, pro_since, birthdate)
+  3. Match history (with surface; opportunistic per-match stats)
+  4. Career stats (8 mapped columns + 50+ JSONB extras)
+
+State is written to /tmp/tennis_backfill_state.json after each phase so the
+script is fully resumable. Re-running picks up at the first non-completed
+phase. Use --restart to ignore prior state.
+
+Usage:
+    python backend/scripts/full_backfill.py
+    python backend/scripts/full_backfill.py --top-n 200
+    python backend/scripts/full_backfill.py --skip-rankings --skip-profiles
+    python backend/scripts/full_backfill.py --restart
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+# Make backend/ and project-root/ importable
+HERE = Path(__file__).resolve().parent
+BACKEND_ROOT = HERE.parent
+PROJECT_ROOT = BACKEND_ROOT.parent
+for p in (str(BACKEND_ROOT), str(PROJECT_ROOT)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from app.config import get_settings  # noqa: E402
+from app.db import SessionLocal  # noqa: E402
+from data.seed_data import (  # noqa: E402
+    backfill_tournaments,
+    fetch_and_populate_coach_data,
+    seed_matches,
+    sync_top200_rankings,
+)
+from data_ingestion.stats_ingester import ingest_player_stats  # noqa: E402
+
+STATE_FILE = Path("/tmp/tennis_backfill_state.json")
+
+logger = logging.getLogger("full_backfill")
+
+
+PHASES = ["rankings", "profiles", "matches", "tournaments", "stats"]
+
+
+def _load_state() -> dict[str, Any]:
+    if not STATE_FILE.exists():
+        return {"completed": [], "started_at": None, "history": []}
+    try:
+        return json.loads(STATE_FILE.read_text())
+    except Exception as e:
+        logger.warning("Could not read state file (%s) — starting fresh.", e)
+        return {"completed": [], "started_at": None, "history": []}
+
+
+def _save_state(state: dict[str, Any]) -> None:
+    STATE_FILE.write_text(json.dumps(state, indent=2, default=str))
+
+
+def _mark_phase(state: dict[str, Any], phase: str, status: str, details: dict | None = None) -> None:
+    entry = {
+        "phase": phase,
+        "status": status,
+        "ts": datetime.utcnow().isoformat() + "Z",
+    }
+    if details:
+        entry["details"] = details
+    state.setdefault("history", []).append(entry)
+    if status == "completed" and phase not in state["completed"]:
+        state["completed"].append(phase)
+    _save_state(state)
+
+
+def _run_rankings(state: dict, top_n: int) -> None:
+    logger.info("=" * 70)
+    logger.info("PHASE 1/5: Sync top-%d rankings", top_n)
+    logger.info("=" * 70)
+    sync_top200_rankings(top_n=top_n)
+    _mark_phase(state, "rankings", "completed", {"top_n": top_n})
+
+
+def _run_profiles(state: dict) -> None:
+    logger.info("=" * 70)
+    logger.info("PHASE 2/5: Player profile backfill (ranked only)")
+    logger.info("=" * 70)
+    fetch_and_populate_coach_data(only_ranked=True)
+    _mark_phase(state, "profiles", "completed")
+
+
+def _run_matches(state: dict) -> None:
+    logger.info("=" * 70)
+    logger.info("PHASE 3/5: Match history backfill")
+    logger.info("=" * 70)
+    seed_matches()
+    _mark_phase(state, "matches", "completed")
+
+
+def _run_tournaments(state: dict) -> None:
+    logger.info("=" * 70)
+    logger.info("PHASE 4/5: Tournament metadata + surface propagation")
+    logger.info("=" * 70)
+    backfill_tournaments()
+    _mark_phase(state, "tournaments", "completed")
+
+
+def _run_stats(state: dict) -> None:
+    logger.info("=" * 70)
+    logger.info("PHASE 5/5: Career stats backfill (ranked players only)")
+    logger.info("=" * 70)
+    settings = get_settings()
+    if not settings.tennis_api_key:
+        raise RuntimeError("TENNIS_API_KEY not configured")
+
+    from sqlalchemy import text as sa_text
+
+    session = SessionLocal()
+    try:
+        # Restrict career-stats ingest to currently-ranked players. The ingester
+        # iterates all players by default, which would include thousands of
+        # historical opponents.
+        ranked_ids = [
+            row[0]
+            for row in session.execute(
+                sa_text(
+                    "SELECT id FROM players "
+                    "WHERE current_ranking IS NOT NULL "
+                    "ORDER BY current_ranking"
+                )
+            )
+        ]
+        logger.info("Ingesting career stats for %d ranked players.", len(ranked_ids))
+        result = ingest_player_stats(
+            session=session,
+            api_key=settings.tennis_api_key,
+            batch_size=50,
+            player_ids=ranked_ids,
+            dry_run=False,
+        )
+        logger.info("Career stats result: %s", result)
+        _mark_phase(state, "stats", "completed", result)
+    finally:
+        session.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--top-n", type=int, default=200, help="Top-N rankings to sync (default 200)")
+    parser.add_argument("--skip-rankings", action="store_true", help="Skip phase 1 (rankings sync)")
+    parser.add_argument("--skip-profiles", action="store_true", help="Skip phase 2 (profile backfill)")
+    parser.add_argument("--skip-matches", action="store_true", help="Skip phase 3 (match backfill)")
+    parser.add_argument("--skip-tournaments", action="store_true", help="Skip phase 4 (tournament metadata)")
+    parser.add_argument("--skip-stats", action="store_true", help="Skip phase 5 (career stats)")
+    parser.add_argument("--restart", action="store_true", help="Ignore existing state and re-run all phases")
+    parser.add_argument("--verbose", action="store_true", help="DEBUG-level logging")
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
+    if args.restart and STATE_FILE.exists():
+        logger.info("--restart: removing %s", STATE_FILE)
+        STATE_FILE.unlink()
+
+    state = _load_state()
+    if state.get("started_at") is None:
+        state["started_at"] = datetime.utcnow().isoformat() + "Z"
+        _save_state(state)
+
+    logger.info("Backfill starting. Already-completed phases: %s", state["completed"] or "(none)")
+    logger.info("State file: %s", STATE_FILE)
+
+    started = time.time()
+
+    skips = {
+        "rankings": args.skip_rankings,
+        "profiles": args.skip_profiles,
+        "matches": args.skip_matches,
+        "tournaments": args.skip_tournaments,
+        "stats": args.skip_stats,
+    }
+    runners = {
+        "rankings": lambda: _run_rankings(state, args.top_n),
+        "profiles": lambda: _run_profiles(state),
+        "matches": lambda: _run_matches(state),
+        "tournaments": lambda: _run_tournaments(state),
+        "stats": lambda: _run_stats(state),
+    }
+
+    failed_phase = None
+
+    for phase in PHASES:
+        if phase in state["completed"]:
+            logger.info("⤳ Skipping phase '%s' (already completed in this state file).", phase)
+            continue
+        if skips[phase]:
+            logger.info("⤳ Skipping phase '%s' (--skip-%s).", phase, phase)
+            continue
+
+        logger.info("\n▶ Running phase: %s", phase)
+        try:
+            runners[phase]()
+        except Exception as e:
+            logger.exception("✗ Phase '%s' failed: %s", phase, e)
+            _mark_phase(state, phase, "failed", {"error": str(e)})
+            failed_phase = phase
+            break
+
+    elapsed = time.time() - started
+    logger.info("=" * 70)
+    logger.info("Backfill orchestrator finished in %d min %d sec", int(elapsed // 60), int(elapsed % 60))
+    logger.info("Completed phases: %s", state["completed"])
+    if failed_phase:
+        logger.error("Stopped at failed phase: %s — re-run to resume.", failed_phase)
+        return 1
+    logger.info("All requested phases done. ✓")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/ingest_player_stats.py
+++ b/backend/scripts/ingest_player_stats.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""
+CLI entry point for player stats data ingestion.
+
+Usage:
+    python ingest_player_stats.py                    # Ingest all players
+    python ingest_player_stats.py --batch-size 100   # Custom batch size
+    python ingest_player_stats.py --dry-run          # Test without writing
+    python ingest_player_stats.py --player-ids 47275,68074  # Test specific players
+"""
+
+import argparse
+import logging
+import sys
+from pathlib import Path
+
+# Add parent directories to path for imports
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from app.config import get_settings
+from app.db import SessionLocal, engine
+from data_ingestion.stats_ingester import ingest_player_stats
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s | %(levelname)-8s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+logger = logging.getLogger(__name__)
+
+
+def main():
+    """Main entry point for stats ingestion CLI."""
+    parser = argparse.ArgumentParser(
+        description="Ingest ATP player career stats from RapidAPI into player_stats table.",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Ingest all players with default batch size (50)
+  python ingest_player_stats.py
+
+  # Use custom batch size
+  python ingest_player_stats.py --batch-size 100
+
+  # Dry run (fetch and transform, no database writes)
+  python ingest_player_stats.py --dry-run
+
+  # Test with specific players
+  python ingest_player_stats.py --player-ids 47275,68074,3320
+
+  # Combine flags
+  python ingest_player_stats.py --player-ids 47275 --dry-run
+        """,
+    )
+    
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=50,
+        help="Number of players to process before batch upsert (default: 50)",
+    )
+    
+    parser.add_argument(
+        "--player-ids",
+        type=str,
+        help="Comma-separated list of player IDs to ingest (for testing)",
+    )
+    
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Fetch and transform data, but don't write to database",
+    )
+    
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable verbose (DEBUG) logging",
+    )
+    
+    args = parser.parse_args()
+    
+    # Set log level
+    if args.verbose:
+        logging.getLogger().setLevel(logging.DEBUG)
+    
+    # Validate batch size
+    if args.batch_size < 1:
+        logger.error("--batch-size must be >= 1")
+        return 1
+    
+    # Parse player IDs if provided
+    player_ids = None
+    if args.player_ids:
+        try:
+            player_ids = [int(pid.strip()) for pid in args.player_ids.split(",")]
+            logger.info(f"Testing with {len(player_ids)} specific players: {player_ids}")
+        except ValueError:
+            logger.error(f"Invalid --player-ids format. Expected comma-separated integers, got: {args.player_ids}")
+            return 1
+    
+    # Load configuration
+    try:
+        settings = get_settings()
+        if not settings.tennis_api_key:
+            logger.error("TENNIS_API_KEY environment variable not set")
+            return 1
+    except Exception as e:
+        logger.error(f"Failed to load settings: {e}")
+        return 1
+    
+    # Verify database connection
+    try:
+        with engine.connect() as conn:
+            logger.info("✓ Database connection verified")
+    except Exception as e:
+        logger.error(f"✗ Database connection failed: {e}")
+        return 1
+    
+    # Run ingestion
+    try:
+        session = SessionLocal()
+        
+        logger.info("=" * 80)
+        logger.info(f"Starting player stats ingestion")
+        logger.info(f"  Batch size: {args.batch_size}")
+        logger.info(f"  Dry run: {args.dry_run}")
+        logger.info(f"  Specific players: {'Yes' if player_ids else 'No'}")
+        logger.info("=" * 80)
+        
+        results = ingest_player_stats(
+            session=session,
+            api_key=settings.tennis_api_key,
+            batch_size=args.batch_size,
+            player_ids=player_ids,
+            dry_run=args.dry_run,
+        )
+        
+        logger.info("=" * 80)
+        logger.info("INGESTION COMPLETE")
+        logger.info(f"  Total players processed: {results['total_players']}")
+        logger.info(f"  ✓ Successful upserts: {results['success_count']}")
+        logger.info(f"  ✗ Failures: {results['failure_count']}")
+        logger.info(f"  ⊘ Skipped: {results['skipped_count']}")
+        
+        if args.dry_run:
+            logger.info("  (DRY RUN - no database writes)")
+        
+        logger.info("=" * 80)
+        
+        session.close()
+        
+        # Exit with error if there were failures
+        if results['failure_count'] > 0:
+            return 1
+        
+        return 0
+        
+    except KeyboardInterrupt:
+        logger.info("\nIngestion cancelled by user")
+        return 130
+    except Exception as e:
+        logger.error(f"Ingestion failed with exception: {e}", exc_info=True)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/data/seed_data.py
+++ b/data/seed_data.py
@@ -5,8 +5,10 @@ Bootstrap utilities for the tennis_scout database.
   seed_players()  – insert/upsert ATP ranking players (idempotent, safe to
                     re-run; does NOT reset schema)
   fetch_and_populate_coach_data() – fetch coach info from ATP API and populate
-                    the coach column for all players (safe to re-run)
-"""
+                    the coach column for all players (safe to re-run)  seed_matches()  – fetch 500 most recent matches per player from ATP API
+                    and populate matches + tournaments tables (idempotent)"""
+
+from __future__ import annotations
 
 from pathlib import Path
 import sys
@@ -19,7 +21,13 @@ from sqlalchemy import create_engine, text
 
 from app.config import get_settings
 from app.models import Base
-from app.services.atp_api_service import fetch_player_profile, extract_player_data_from_profile
+from app.services.atp_api_service import (
+    fetch_atp_rankings,
+    fetch_player_matches,
+    fetch_player_profile,
+    fetch_tournament_info,
+    extract_player_data_from_profile,
+)
 
 settings = get_settings()
 engine = create_engine(settings.postgres_url, pool_pre_ping=True)
@@ -177,17 +185,676 @@ def seed_players() -> None:
         print("Sequence players_id_seq advanced past max explicit id.")
 
 
-if __name__ == "__main__":
-    seed_players()
+def sync_top200_rankings(top_n: int = 200) -> None:
+    """
+    Fetch the live top-N ATP rankings and upsert them into the players table.
+
+    For new player IDs: insert a full row (id, names, full_name, country, rank).
+    For existing IDs: only refresh `current_ranking` (don't overwrite the
+    curated names/country we already have).
+
+    Players currently ranked outside the top-N keep their old `current_ranking`
+    value (we do NOT clear ranks for missing players — that would invalidate
+    the existing 101 seed). If you want a clean refresh, call reset_schema()
+    first.
+
+    Idempotent — safe to re-run.
+    """
+    print(f"Fetching top {top_n} ATP rankings from API...")
+    rankings = fetch_atp_rankings(top_n=top_n, debug_log_first_response=True)
+
+    if not rankings:
+        print("✗ No ranking entries returned from API. Aborting.")
+        return
+
+    print(f"✓ Got {len(rankings)} ranking entries from API.")
+
+    # Insert new players: full row, ON CONFLICT DO NOTHING
+    insert_sql = text("""
+        INSERT INTO players (
+            id, first_name, last_name, full_name, country, current_ranking,
+            birthdate, height_cm, weight_kg, handedness, backhand_type, pro_since
+        ) VALUES (
+            :id, :first_name, :last_name, :full_name, :country, :current_ranking,
+            NULL, NULL, NULL, NULL, NULL, NULL
+        )
+        ON CONFLICT (id) DO NOTHING
+    """)
+
+    # Update ranking for already-existing rows (run separately so we don't
+    # clobber curated names/country).
+    update_rank_sql = text("""
+        UPDATE players SET current_ranking = :current_ranking WHERE id = :id
+    """)
+
+    advance_seq_sql = text("""
+        SELECT setval(
+            'players_id_seq',
+            GREATEST((SELECT MAX(id) FROM players), nextval('players_id_seq') - 1) + 1
+        )
+    """)
+
+    rows = []
+    for r in rankings:
+        # Defensive: make sure full_name is unique-ish; the players table has
+        # a UNIQUE constraint on full_name. Append id only if name collides.
+        full_name = r["full_name"] or f"{r['first_name']} {r['last_name']}".strip()
+        if not full_name:
+            full_name = f"Player {r['player_id']}"
+        rows.append({
+            "id": r["player_id"],
+            "first_name": r["first_name"] or "",
+            "last_name": r["last_name"] or "",
+            "full_name": full_name,
+            "country": r["country"],
+            "current_ranking": r["rank"],
+        })
+
+    # Resolve full_name collisions against existing DB rows that have a
+    # different id (UNIQUE constraint will reject otherwise).
+    with engine.begin() as conn:
+        existing = {
+            row[1].lower(): row[0]
+            for row in conn.execute(text("SELECT id, full_name FROM players")).fetchall()
+        }
+        # Drop any new entries whose full_name collides with a different id —
+        # they're almost certainly the same person under a slight name variant
+        # already in the DB; we just refresh the existing row's rank.
+        deduped = []
+        for row in rows:
+            key = row["full_name"].lower()
+            existing_id = existing.get(key)
+            if existing_id is not None and existing_id != row["id"]:
+                # Same name, different id → assume it's the same player; just
+                # update the existing id's ranking.
+                conn.execute(update_rank_sql, {
+                    "id": existing_id,
+                    "current_ranking": row["current_ranking"],
+                })
+                continue
+            deduped.append(row)
+
+        # Now insert (skips on id-conflict)
+        result = conn.execute(insert_sql, deduped)
+        inserted = result.rowcount
+        # Update rankings for all top-N entries (including just-inserted ones —
+        # cheap and ensures rank is current for everyone).
+        conn.execute(update_rank_sql, deduped)
+        conn.execute(advance_seq_sql)
+
+    print(f"✓ Inserted {inserted} new player(s); refreshed ranking for {len(deduped)} entries.")
 
 
-def fetch_and_populate_coach_data() -> None:
+# ---------------------------------------------------------------------------
+# Round ID → human-readable round name mapping (from ATP API)
+# ---------------------------------------------------------------------------
+ROUND_MAP = {
+    4: "R128",
+    5: "R64",
+    6: "R32",
+    7: "R16",
+    9: "Quarters",
+    10: "Semis",
+    12: "Finals",
+}
+
+
+def _extract_match_surface(m: dict) -> str | None:
+    """Best-effort surface extraction from a past-matches response entry."""
+    # Try direct keys first
+    for key in ("surface", "court", "courtType", "surfaceType", "groundType"):
+        v = m.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+        if isinstance(v, dict):
+            name = v.get("name") or v.get("type")
+            if isinstance(name, str) and name.strip():
+                return name.strip()
+    # Try nested under tournament
+    t = m.get("tournament") if isinstance(m.get("tournament"), dict) else {}
+    for key in ("surface", "court", "surfaceType"):
+        v = t.get(key)
+        if isinstance(v, str) and v.strip():
+            return v.strip()
+    return None
+
+
+# Field name candidates for per-player per-match stats. We probe each match
+# dict for these and, if any are found, write a PlayerStats row. The mapping
+# is intentionally permissive — the actual API may use different keys, in
+# which case nothing will be written and we fall back to career stats.
+_PER_MATCH_STAT_KEYS_PLAYER1 = {
+    "aces": ["player1Aces", "p1Aces", "aces1", "acesPlayer1"],
+    "double_faults": ["player1DoubleFaults", "p1DoubleFaults", "doubleFaults1"],
+    "first_serve_pct": ["player1FirstServePercentage", "p1FirstServePercentage", "firstServePercentage1"],
+    "first_serve_win_pct": ["player1FirstServeWonPercentage", "p1FirstServeWonPercentage", "winningOnFirstServePercentage1"],
+    "second_serve_win_pct": ["player1SecondServeWonPercentage", "p1SecondServeWonPercentage", "winningOnSecondServePercentage1"],
+    "break_points_saved_pct": ["player1BreakPointsSavedPercentage", "p1BreakPointsSavedPercentage"],
+    "break_points_converted_pct": ["player1BreakPointsConvertedPercentage", "p1BreakPointsConvertedPercentage"],
+    "service_games_won_pct": ["player1ServiceGamesWonPercentage", "p1ServiceGamesWonPercentage"],
+    "return_games_won_pct": ["player1ReturnGamesWonPercentage", "p1ReturnGamesWonPercentage"],
+    "return_points_won_pct": ["player1ReturnPointsWonPercentage", "p1ReturnPointsWonPercentage"],
+    "tiebreaks_won_pct": ["player1TiebreaksWonPercentage", "p1TiebreaksWonPercentage"],
+}
+
+_PER_MATCH_STAT_KEYS_PLAYER2 = {
+    col: [k.replace("player1", "player2").replace("p1", "p2").replace("1", "2") for k in keys]
+    for col, keys in _PER_MATCH_STAT_KEYS_PLAYER1.items()
+}
+
+
+def _coerce_number(v):
+    """Best-effort numeric coercion; returns None if not coercible."""
+    if v is None or v == "":
+        return None
+    if isinstance(v, (int, float)):
+        return v
+    try:
+        s = str(v).strip().rstrip("%")
+        if "." in s:
+            return float(s)
+        return int(s)
+    except (ValueError, TypeError):
+        return None
+
+
+def _extract_per_match_stats(m: dict, player_field_map: dict) -> dict | None:
+    """
+    Extract per-match stats for a single player from a match dict, using a
+    column→candidate-keys map. Returns None if nothing found.
+    """
+    out: dict = {}
+    for col, candidates in player_field_map.items():
+        for k in candidates:
+            if k in m and m[k] not in (None, ""):
+                v = _coerce_number(m[k])
+                if v is not None:
+                    out[col] = v
+                    break
+    return out or None
+
+
+def seed_matches() -> None:
+    """
+    Fetch the 500 most recent matches for every player in the players table
+    via the ATP API and populate the matches (and tournaments) tables.
+
+    Workflow:
+      1. Read all player IDs from the players table.
+      2. For each player, call the past-matches API endpoint.
+      3. Deduplicate matches globally (two seeded players may share a match).
+      4. Insert any unknown opponents into the players table (minimal rows).
+      5. Insert any unknown tournament IDs into the tournaments table.
+      6. Bulk-insert all unique matches (with surface).
+      7. Opportunistically write per-match player_stats rows if the API
+         response carries per-match stat fields.
+
+    Fully idempotent — UPSERT on conflict for surface so re-runs backfill it.
+    """
+    from datetime import date as date_type
+
+    # -- 1. Load only seeded players (those with a ranking) from the DB --------
+    print("Fetching all players from database...")
+    with engine.begin() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT id, full_name FROM players "
+                "WHERE current_ranking IS NOT NULL "
+                "ORDER BY current_ranking"
+            )
+        )
+        players = rows.fetchall()
+
+    total_players = len(players)
+    print(f"Found {total_players} players to process.")
+    print("Starting to fetch match history from ATP API (1.5s delay between requests)...\n")
+
+    # -- 2. Fetch matches per player & deduplicate ----------------------------
+    all_matches: dict[int, dict] = {}      # match API id → raw dict
+    all_player_refs: dict[int, dict] = {}  # player API id → {id, name, countryAcr}
+    all_tournament_ids: set[int] = set()
+    error_count = 0
+    debug_dumped = False  # Print first match dict once for shape inspection
+
+    for idx, (player_id, player_name) in enumerate(players, 1):
+        try:
+            matches = fetch_player_matches(player_id, delay=1.5)
+
+            if not debug_dumped and matches:
+                print(f"  [debug] First match dict keys: {sorted(matches[0].keys())}")
+                print(f"  [debug] First match sample: {matches[0]!r}")
+                debug_dumped = True
+
+            new = 0
+            for m in matches:
+                mid = int(m["id"])
+                if mid not in all_matches:
+                    all_matches[mid] = m
+                    new += 1
+
+                # Collect every player reference for opponent resolution
+                for pkey in ("player1", "player2"):
+                    p = m.get(pkey, {})
+                    pid = p.get("id")
+                    if pid and pid not in all_player_refs:
+                        all_player_refs[pid] = p
+
+                # Collect tournament IDs
+                tid = m.get("tournamentId")
+                if tid:
+                    all_tournament_ids.add(tid)
+
+            print(f"[{idx}/{total_players}] ✓ {player_name} — {len(matches)} matches fetched, {new} new unique")
+        except Exception as e:
+            print(f"[{idx}/{total_players}] ✗ {player_name} — ERROR: {e}")
+            error_count += 1
+
+    print(f"\nAPI fetch complete. {len(all_matches)} unique matches collected, {error_count} errors.")
+
+    if not all_matches:
+        print("No matches to insert — done.")
+        return
+
+    # -- 3. Insert unknown opponents into the players table -------------------
+    # Gather IDs already in the DB
+    with engine.begin() as conn:
+        existing_ids = set(
+            r[0] for r in conn.execute(text("SELECT id FROM players")).fetchall()
+        )
+
+    new_players = []
+    seen_full_names: set[str] = set()
+    # Also collect existing full_names from the DB to avoid unique constraint violations
+    with engine.begin() as conn:
+        existing_names = set(
+            r[0].lower() for r in conn.execute(text("SELECT full_name FROM players")).fetchall()
+        )
+
+    for pid, pdata in all_player_refs.items():
+        if pid not in existing_ids:
+            name = pdata.get("name", "Unknown")
+            # Handle "Unknown Player" or blank names — make unique by appending player ID
+            if not name or name.strip().lower() in ("unknown", "unknown player", ""):
+                name = f"Unknown Player {pid}"
+            # Deduplicate by full_name (case-insensitive) across both DB and this batch
+            if name.lower() in existing_names or name.lower() in seen_full_names:
+                continue
+            seen_full_names.add(name.lower())
+            parts = name.split(" ", 1)
+            first_name = parts[0]
+            last_name = parts[1] if len(parts) > 1 else ""
+            new_players.append({
+                "id": pid,
+                "first_name": first_name,
+                "last_name": last_name,
+                "full_name": name,
+                "country": pdata.get("countryAcr"),
+            })
+
+    if new_players:
+        print(f"Inserting {len(new_players)} new opponent player(s)...")
+        insert_player_sql = text("""
+            INSERT INTO players (id, first_name, last_name, full_name, country)
+            VALUES (:id, :first_name, :last_name, :full_name, :country)
+            ON CONFLICT (id) DO NOTHING
+        """)
+        with engine.begin() as conn:
+            conn.execute(insert_player_sql, new_players)
+            # Advance the players sequence past the max explicit id
+            conn.execute(text("""
+                SELECT setval(
+                    'players_id_seq',
+                    GREATEST((SELECT MAX(id) FROM players), nextval('players_id_seq') - 1) + 1
+                )
+            """))
+        print("Opponent players inserted.")
+    else:
+        print("No new opponent players to insert.")
+
+    # -- 4. Insert tournament stubs -------------------------------------------
+    if all_tournament_ids:
+        print(f"Inserting {len(all_tournament_ids)} tournament stub(s)...")
+        insert_tournament_sql = text("""
+            INSERT INTO tournaments (id, name)
+            VALUES (:id, :name)
+            ON CONFLICT (id) DO NOTHING
+        """)
+        tournament_rows = [{"id": tid, "name": f"Tournament {tid}"} for tid in all_tournament_ids]
+        with engine.begin() as conn:
+            conn.execute(insert_tournament_sql, tournament_rows)
+            conn.execute(text("""
+                SELECT setval(
+                    'tournaments_id_seq',
+                    GREATEST((SELECT MAX(id) FROM tournaments), nextval('tournaments_id_seq') - 1) + 1
+                )
+            """))
+        print("Tournament stubs inserted.")
+
+    # -- 5. Bulk-insert matches (with surface) --------------------------------
+    print(f"Inserting/updating {len(all_matches)} match(es)...")
+
+    # Collect (player_id, match_id, period='match', stats) rows opportunistically
+    per_match_stat_rows: list[dict] = []
+    surface_seen = 0
+
+    match_rows = []
+    for mid, m in all_matches.items():
+        # Parse date
+        match_date = None
+        raw_date = m.get("date")
+        if raw_date:
+            try:
+                match_date = date_type.fromisoformat(raw_date[:10])
+            except (ValueError, TypeError):
+                pass
+
+        # Map roundId → round name
+        round_id = m.get("roundId")
+        round_name = ROUND_MAP.get(round_id)
+
+        surface = _extract_match_surface(m)
+        if surface:
+            surface_seen += 1
+
+        match_rows.append({
+            "id": mid,
+            "date": match_date,
+            "tournament_id": m.get("tournamentId"),
+            "round": round_name,
+            "surface": surface,
+            "player1_id": m["player1Id"],
+            "player2_id": m["player2Id"],
+            "winner_id": m.get("match_winner"),
+            "score": m.get("result"),
+        })
+
+        # Per-match stats (opportunistic) — for player1 and player2
+        p1_stats = _extract_per_match_stats(m, _PER_MATCH_STAT_KEYS_PLAYER1)
+        p2_stats = _extract_per_match_stats(m, _PER_MATCH_STAT_KEYS_PLAYER2)
+        if p1_stats:
+            per_match_stat_rows.append({
+                "player_id": m["player1Id"],
+                "match_id": mid,
+                "period": "match",
+                "surface": surface,
+                **{col: p1_stats.get(col) for col in _PER_MATCH_STAT_KEYS_PLAYER1.keys()},
+            })
+        if p2_stats:
+            per_match_stat_rows.append({
+                "player_id": m["player2Id"],
+                "match_id": mid,
+                "period": "match",
+                "surface": surface,
+                **{col: p2_stats.get(col) for col in _PER_MATCH_STAT_KEYS_PLAYER2.keys()},
+            })
+
+    print(f"  Surface populated for {surface_seen}/{len(match_rows)} matches.")
+
+    # UPSERT — keep new fields current on re-run (especially `surface`, which
+    # was previously dropped on insert).
+    insert_match_sql = text("""
+        INSERT INTO matches (id, date, tournament_id, round, surface,
+                             player1_id, player2_id, winner_id, score)
+        VALUES (:id, :date, :tournament_id, :round, :surface,
+                :player1_id, :player2_id, :winner_id, :score)
+        ON CONFLICT (id) DO UPDATE SET
+            surface = COALESCE(EXCLUDED.surface, matches.surface),
+            tournament_id = COALESCE(EXCLUDED.tournament_id, matches.tournament_id),
+            round = COALESCE(EXCLUDED.round, matches.round),
+            winner_id = COALESCE(EXCLUDED.winner_id, matches.winner_id),
+            date = COALESCE(EXCLUDED.date, matches.date),
+            score = COALESCE(EXCLUDED.score, matches.score)
+    """)
+
+    BATCH_SIZE = 500
+    inserted_total = 0
+    for i in range(0, len(match_rows), BATCH_SIZE):
+        batch = match_rows[i : i + BATCH_SIZE]
+        with engine.begin() as conn:
+            result = conn.execute(insert_match_sql, batch)
+            inserted_total += result.rowcount
+
+    # Advance the matches sequence
+    with engine.begin() as conn:
+        conn.execute(text("""
+            SELECT setval(
+                'matches_id_seq',
+                GREATEST((SELECT MAX(id) FROM matches), nextval('matches_id_seq') - 1) + 1
+            )
+        """))
+
+    # -- 6. Per-match player_stats rows (opportunistic) -----------------------
+    per_match_inserted = 0
+    if per_match_stat_rows:
+        print(f"Writing {len(per_match_stat_rows)} per-match player_stats row(s)...")
+        match_ids_to_clear = list({r["match_id"] for r in per_match_stat_rows})
+        # Clear any prior period='match' rows for these match_ids so re-runs
+        # are idempotent (no unique constraint to ON CONFLICT against).
+        with engine.begin() as conn:
+            conn.execute(
+                text(
+                    "DELETE FROM player_stats "
+                    "WHERE period = 'match' AND match_id = ANY(:mids)"
+                ),
+                {"mids": match_ids_to_clear},
+            )
+
+        # Filter out rows whose player_id is not in players (ON DELETE CASCADE
+        # foreign key would reject otherwise). All player1/player2 ids should
+        # be present after Phase 4 (opponent insertion above) but be safe.
+        with engine.begin() as conn:
+            existing_player_ids = {
+                r[0] for r in conn.execute(text("SELECT id FROM players")).fetchall()
+            }
+        clean_rows = [r for r in per_match_stat_rows if r["player_id"] in existing_player_ids]
+
+        insert_stats_sql = text("""
+            INSERT INTO player_stats (
+                player_id, match_id, period, surface,
+                aces, double_faults, first_serve_pct, first_serve_win_pct,
+                second_serve_win_pct, return_points_won_pct,
+                break_points_saved_pct, break_points_converted_pct,
+                service_games_won_pct, return_games_won_pct, tiebreaks_won_pct
+            ) VALUES (
+                :player_id, :match_id, :period, :surface,
+                :aces, :double_faults, :first_serve_pct, :first_serve_win_pct,
+                :second_serve_win_pct, :return_points_won_pct,
+                :break_points_saved_pct, :break_points_converted_pct,
+                :service_games_won_pct, :return_games_won_pct, :tiebreaks_won_pct
+            )
+        """)
+
+        # Ensure every row has all keys (defaulting to None) so the bind works
+        all_cols = list(_PER_MATCH_STAT_KEYS_PLAYER1.keys())
+        for r in clean_rows:
+            for c in all_cols:
+                r.setdefault(c, None)
+
+        with engine.begin() as conn:
+            for i in range(0, len(clean_rows), BATCH_SIZE):
+                batch = clean_rows[i : i + BATCH_SIZE]
+                result = conn.execute(insert_stats_sql, batch)
+                per_match_inserted += result.rowcount
+    else:
+        print("  No per-match stat fields found in API response — skipping.")
+        print("  (Career stats from Phase 4 ingester will still be available.)")
+
+    print(f"Inserted/updated {inserted_total} match row(s).")
+    print("\n" + "=" * 70)
+    print("Match seeding complete!")
+    print(f"  Unique matches collected:    {len(all_matches)}")
+    print(f"  Match rows upserted:         {inserted_total}")
+    print(f"  Surface populated on rows:   {surface_seen}")
+    print(f"  Per-match stat rows written: {per_match_inserted}")
+    print(f"  New opponent players:        {len(new_players)}")
+    print(f"  Tournament stubs:            {len(all_tournament_ids)}")
+    print(f"  Player fetch errors:         {error_count}")
+    print("=" * 70)
+
+
+def backfill_tournaments(only_ranked_meetings: bool = True) -> None:
+    """
+    Fetch full tournament metadata (name, surface, country, date, tier) from
+    the ATP API and propagate the resulting surface to each match referencing
+    that tournament.
+
+    By default (`only_ranked_meetings=True`), only fetches info for tournaments
+    that host at least one match between two currently-ranked players — the
+    set that matters for top-200 H2H analysis. Tournaments with surface
+    already populated are skipped (idempotent across runs).
+
+    Set `only_ranked_meetings=False` to backfill every tournament_id in the
+    tournaments table (slow: 5000+ tournaments at 1.5s each).
+
+    Workflow:
+      1. Pick tournament IDs to fetch (filtered + missing-surface only).
+      2. For each, call /tennis/v2/atp/tournament/info/{id}/.
+      3. UPDATE tournaments SET name, surface, location, start_date, category.
+      4. UPDATE matches SET surface = tournaments.surface WHERE
+         matches.tournament_id = tournaments.id AND matches.surface IS NULL.
+
+    Surface values come from the tournament's `court.name` (e.g. "Clay", "Hard").
+    """
+    from datetime import datetime
+
+    if only_ranked_meetings:
+        print("Picking tournaments hosting matches between two ranked players (missing surface)...")
+        sql = """
+            SELECT DISTINCT m.tournament_id
+            FROM matches m
+            JOIN players p1 ON p1.id = m.player1_id AND p1.current_ranking IS NOT NULL
+            JOIN players p2 ON p2.id = m.player2_id AND p2.current_ranking IS NOT NULL
+            JOIN tournaments t ON t.id = m.tournament_id
+            WHERE m.tournament_id IS NOT NULL
+              AND (t.surface IS NULL OR t.surface = '')
+            ORDER BY m.tournament_id
+        """
+    else:
+        print("Picking ALL tournaments missing surface...")
+        sql = """
+            SELECT id FROM tournaments
+            WHERE surface IS NULL OR surface = ''
+            ORDER BY id
+        """
+
+    with engine.begin() as conn:
+        rows = conn.execute(text(sql)).fetchall()
+    tids = [r[0] for r in rows]
+
+    total = len(tids)
+    if total == 0:
+        print("No tournaments in DB — run --matches first.")
+        return
+
+    print(f"Found {total} tournaments. Fetching info from API (1.5s delay)...\n")
+    updated = 0
+    error_count = 0
+
+    update_sql = text("""
+        UPDATE tournaments
+        SET name = COALESCE(:name, name),
+            surface = COALESCE(:surface, surface),
+            location = COALESCE(:location, location),
+            start_date = COALESCE(:start_date, start_date),
+            category = COALESCE(:category, category)
+        WHERE id = :id
+    """)
+
+    for idx, tid in enumerate(tids, 1):
+        try:
+            info = fetch_tournament_info(tid, delay=1.5)
+            if not info:
+                print(f"[{idx}/{total}] ✗ Tournament {tid} — no data")
+                error_count += 1
+                continue
+
+            # Surface from court.name
+            surface = None
+            court = info.get("court")
+            if isinstance(court, dict):
+                surface = court.get("name")
+            if not surface and isinstance(info.get("courtId"), int):
+                # If court name missing, leave null
+                surface = None
+
+            # Location from country.name (or "coutry" — yes the API has a typo)
+            location = None
+            country = info.get("country") or info.get("coutry")
+            if isinstance(country, dict):
+                location = country.get("name")
+
+            # Start date
+            start_date = None
+            raw_date = info.get("date") or info.get("startDate")
+            if raw_date:
+                try:
+                    start_date = datetime.fromisoformat(raw_date.replace("Z", "+00:00")).date()
+                except (ValueError, TypeError):
+                    pass
+
+            with engine.begin() as conn:
+                conn.execute(update_sql, {
+                    "id": tid,
+                    "name": info.get("name"),
+                    "surface": surface,
+                    "location": location,
+                    "start_date": start_date,
+                    "category": info.get("tier"),
+                })
+
+            print(f"[{idx}/{total}] ✓ Tournament {tid} — {info.get('name')!r} | surface={surface} | tier={info.get('tier')}")
+            updated += 1
+
+        except Exception as e:
+            print(f"[{idx}/{total}] ✗ Tournament {tid} — ERROR: {e}")
+            error_count += 1
+
+    # Propagate surface from tournaments → matches
+    print("\nPropagating surface from tournaments → matches...")
+    with engine.begin() as conn:
+        result = conn.execute(text("""
+            UPDATE matches
+            SET surface = tournaments.surface
+            FROM tournaments
+            WHERE matches.tournament_id = tournaments.id
+              AND tournaments.surface IS NOT NULL
+              AND (matches.surface IS NULL OR matches.surface = '')
+        """))
+        propagated = result.rowcount
+
+    # Also propagate to any per-match player_stats rows we already wrote
+    with engine.begin() as conn:
+        conn.execute(text("""
+            UPDATE player_stats AS ps
+            SET surface = m.surface
+            FROM matches m
+            WHERE ps.match_id = m.id
+              AND m.surface IS NOT NULL
+              AND (ps.surface IS NULL OR ps.surface = '')
+        """))
+
+    print("=" * 70)
+    print("Tournament backfill complete!")
+    print(f"  Tournaments updated: {updated}")
+    print(f"  Errors:              {error_count}")
+    print(f"  Match rows surfaced: {propagated}")
+    print("=" * 70)
+
+
+def fetch_and_populate_coach_data(only_ranked: bool = True) -> None:
     """
     Fetch player information from ATP API and populate database with all available data.
 
     Uses a 1.5-second delay between requests to respect API rate limits.
-    Updates: coach, height_cm, weight_kg, handedness, backhand_type, pro_since
+    Updates: coach, height_cm, weight_kg, handedness, backhand_type,
+             pro_since, birthdate
     Idempotent — safe to run multiple times.
+
+    Args:
+        only_ranked: If True (default), only process players with a non-null
+            `current_ranking` (i.e. the seeded/synced top-N). If False, process
+            every player in the table — includes thousands of historical
+            opponents and is expensive.
     """
     # First ensure the coach column exists (in case it's a fresh setup)
     print("Ensuring coach column exists...")
@@ -197,10 +864,14 @@ def fetch_and_populate_coach_data() -> None:
             ADD COLUMN IF NOT EXISTS coach VARCHAR(120);
         """))
 
-    # Fetch all players from database
-    print("Fetching all players from database...")
+    # Fetch players from database (filtered to ranked by default)
+    where_clause = "WHERE current_ranking IS NOT NULL" if only_ranked else ""
+    order_clause = "ORDER BY current_ranking" if only_ranked else "ORDER BY id"
+    print(f"Fetching players from database ({'ranked only' if only_ranked else 'all'})...")
     with engine.begin() as conn:
-        result = conn.execute(text("SELECT id, full_name FROM players ORDER BY id"))
+        result = conn.execute(
+            text(f"SELECT id, full_name FROM players {where_clause} {order_clause}")
+        )
         players = result.fetchall()
 
     total_players = len(players)
@@ -225,7 +896,8 @@ def fetch_and_populate_coach_data() -> None:
                         weight_kg = :weight_kg,
                         handedness = :handedness,
                         backhand_type = :backhand_type,
-                        pro_since = :pro_since
+                        pro_since = :pro_since,
+                        birthdate = COALESCE(:birthdate, birthdate)
                     WHERE id = :id
                 """)
                 result = conn.execute(update_sql, {
@@ -236,6 +908,7 @@ def fetch_and_populate_coach_data() -> None:
                     "handedness": player_data["handedness"],
                     "backhand_type": player_data["backhand_type"],
                     "pro_since": player_data["pro_since"],
+                    "birthdate": player_data.get("birthdate"),
                 })
 
             # Build status message with populated fields
@@ -252,6 +925,8 @@ def fetch_and_populate_coach_data() -> None:
                 status_parts.append(f"Backhand: {player_data['backhand_type']}")
             if player_data["pro_since"]:
                 status_parts.append(f"Pro Since: {player_data['pro_since']}")
+            if player_data.get("birthdate"):
+                status_parts.append(f"DOB: {player_data['birthdate']}")
 
             status = f"✓ {player_name}"
             if status_parts:
@@ -271,3 +946,33 @@ def fetch_and_populate_coach_data() -> None:
     print(f"  Total processed: {updated_count + error_count}/{total_players}")
     print("=" * 70)
 
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Tennis Scout DB bootstrap utilities")
+    parser.add_argument("--reset", action="store_true", help="Drop & recreate all tables")
+    parser.add_argument("--players", action="store_true", help="Seed players table from hardcoded list")
+    parser.add_argument("--sync-rankings", action="store_true", help="Sync top-200 rankings from API")
+    parser.add_argument("--coaches", action="store_true", help="Fetch & populate coach/profile data")
+    parser.add_argument("--matches", action="store_true", help="Fetch & populate matches")
+    parser.add_argument("--tournaments", action="store_true", help="Fetch tournament info & propagate surface to matches")
+    parser.add_argument("--top-n", type=int, default=200, help="Top-N rankings to sync (default 200)")
+    args = parser.parse_args()
+
+    # Default to --players if no flag is given
+    if not any([args.reset, args.players, args.sync_rankings, args.coaches, args.matches, args.tournaments]):
+        args.players = True
+
+    if args.reset:
+        reset_schema()
+    if args.players:
+        seed_players()
+    if args.sync_rankings:
+        sync_top200_rankings(top_n=args.top_n)
+    if args.coaches:
+        fetch_and_populate_coach_data()
+    if args.matches:
+        seed_matches()
+    if args.tournaments:
+        backfill_tournaments()

--- a/frontend/src/components/ComparisonView.jsx
+++ b/frontend/src/components/ComparisonView.jsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown'
 export default function ComparisonView({ data, onBack }) {
   if (!data) return null
 
-  const { players, snapshots, report, llm } = data
+  const { players, snapshots, h2h, report, llm } = data
   const isLLMUnavailable = llm?.status === 'unavailable' || !llm
 
   return (
@@ -34,11 +34,117 @@ export default function ComparisonView({ data, onBack }) {
         ))}
       </div>
 
+      {/* H2H */}
+      <H2HSection h2h={h2h} players={players} />
+
       {/* Stats Comparison */}
       <StatsComparison snapshots={snapshots} />
 
       {/* AI Analysis */}
       <AnalysisSection report={report} llm={llm} isUnavailable={isLLMUnavailable} />
+    </div>
+  )
+}
+
+/* ───────────── Head-to-Head ───────────── */
+
+function H2HSection({ h2h, players }) {
+  if (!h2h || !players || players.length < 2) return null
+
+  const [p1, p2] = players
+  const rec = h2h.record || {}
+  const total = rec.total_meetings ?? 0
+  const p1Wins = rec.player1_wins ?? 0
+  const p2Wins = rec.player2_wins ?? 0
+
+  let headline
+  if (total === 0) {
+    headline = 'No prior meetings'
+  } else if (p1Wins > p2Wins) {
+    headline = `${p1.name} leads ${p1Wins}–${p2Wins}`
+  } else if (p2Wins > p1Wins) {
+    headline = `${p2.name} leads ${p2Wins}–${p1Wins}`
+  } else {
+    headline = `Tied ${p1Wins}–${p2Wins}`
+  }
+
+  const surfaces = Object.entries(h2h.surface_split || {})
+  const meetings = h2h.meetings || []
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/60">
+      <div className="flex items-center justify-between border-b border-slate-800 p-4">
+        <h3 className="text-lg font-semibold">Head-to-Head</h3>
+        <span className="text-sm text-slate-300">
+          {headline}{total > 0 ? ` · ${total} meeting${total !== 1 ? 's' : ''}` : ''}
+        </span>
+      </div>
+
+      {total === 0 && (
+        <div className="p-4 text-sm text-slate-400">
+          These two players have no recorded meetings in the database.
+        </div>
+      )}
+
+      {total > 0 && surfaces.length > 0 && (
+        <div className="border-b border-slate-800/60 p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+            Surface Split
+          </h4>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-slate-400">
+                <th className="px-3 py-1.5 text-left font-medium">{p1.name}</th>
+                <th className="px-3 py-1.5 text-center font-medium">Surface</th>
+                <th className="px-3 py-1.5 text-right font-medium">{p2.name}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {surfaces.map(([surface, split]) => (
+                <tr key={surface} className="border-t border-slate-800/60">
+                  <td className={`px-3 py-1.5 text-left font-semibold ${split.player1_wins > split.player2_wins ? 'text-emerald-400' : ''}`}>
+                    {split.player1_wins}
+                  </td>
+                  <td className="px-3 py-1.5 text-center capitalize text-slate-400">{surface}</td>
+                  <td className={`px-3 py-1.5 text-right font-semibold ${split.player2_wins > split.player1_wins ? 'text-emerald-400' : ''}`}>
+                    {split.player2_wins}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {meetings.length > 0 && (
+        <div className="overflow-x-auto p-4">
+          <h4 className="mb-2 text-xs font-semibold uppercase tracking-wider text-slate-500">
+            Recent Meetings
+          </h4>
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-slate-400">
+                <th className="px-3 py-1.5 text-left font-medium">Date</th>
+                <th className="px-3 py-1.5 text-left font-medium">Tournament</th>
+                <th className="px-3 py-1.5 text-left font-medium">Surface</th>
+                <th className="px-3 py-1.5 text-left font-medium">Winner</th>
+                <th className="px-3 py-1.5 text-left font-medium">Score</th>
+              </tr>
+            </thead>
+            <tbody>
+              {meetings.map((m) => (
+                <tr key={m.match_id} className="border-t border-slate-800/60">
+                  <td className="px-3 py-1.5 text-slate-300">{m.date || '—'}</td>
+                  <td className="px-3 py-1.5 text-slate-300">{m.tournament || '—'}</td>
+                  <td className="px-3 py-1.5 text-slate-300 capitalize">{m.surface || '—'}</td>
+                  <td className="px-3 py-1.5 font-semibold text-slate-100">{m.winner_name || '—'}</td>
+                  <td className="px-3 py-1.5 text-slate-300">{m.score || '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
Populate matches, profiles, tournaments, and career stats for the top 200 ATP players, and add real head-to-head computation to the Compare Players feature so the LLM stops hallucinating H2H records.

Backend:
- New atp_api_service helpers: fetch_atp_rankings, fetch_tournament_info, birthdate parsing.
- data_service: new compute_h2h() and compare_players_with_h2h() — derive record, surface split, and last 10 meetings from the matches table.
- llm_service.build_compare_prompt now accepts the H2H block and feeds concrete numbers into the prompt; instructs the model to use only the supplied figures.
- /compare route returns "h2h" alongside players + snapshots.

Data ingestion:
- seed_data.sync_top200_rankings: live API rank refresh + UPSERT.
- seed_data.backfill_tournaments: enriches tournament metadata and propagates court.name as match.surface (defaults to ranked-vs-ranked meetings only to keep runtime sane).
- seed_data.seed_matches: now captures surface, UPSERTs with COALESCE so re-runs backfill missing fields, and opportunistically writes per-match player_stats when the API exposes them.
- seed_data.fetch_and_populate_coach_data: only_ranked filter + birthdate.
- New backend/scripts/full_backfill.py: orchestrator with state-based resume across rankings/profiles/matches/tournaments/stats phases.
- Carry over existing data_ingestion/stats_ingester.py and scripts/ingest_player_stats.py (the orchestrator imports them).

Frontend:
- ComparisonView renders a new H2HSection between the player cards and the stats table: headline ("Alcaraz leads 11-7 · 18 meetings"), surface-split mini-table, and a recent-meetings table.
- Falls back to "no prior meetings" gracefully.