### PR TITLE
Add player-name autocomplete to Scout and Compare tabs

### DIFF
--- a/backend/app/routes/player_routes.py
+++ b/backend/app/routes/player_routes.py
@@ -1,7 +1,11 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Query
 from pydantic import BaseModel, Field
 
-from app.services.data_service import compare_players_with_h2h, get_player_snapshot
+from app.services.data_service import (
+    compare_players_with_h2h,
+    get_player_snapshot,
+    search_players,
+)
 from app.services.llm_service import (
     build_compare_prompt,
     build_player_prompt,
@@ -13,6 +17,14 @@ router = APIRouter(tags=["players"])
 
 class CompareRequest(BaseModel):
     player_names: list[str] = Field(default_factory=list, min_length=2, validate_default=True, description="List of player names to compare (at least 2).")
+
+
+@router.get("/players/search")
+def search_player_names(
+    q: str = Query(..., min_length=1, max_length=100),
+    limit: int = Query(8, ge=1, le=20),
+) -> dict:
+    return {"results": search_players(q, limit)}
 
 
 @router.get("/player/{name}")

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -211,6 +211,31 @@ def get_player_snapshot(player_name: str) -> dict | None:
         return _get_player_snapshot_with_session(session, player_name)
 
 
+def search_players(query: str, limit: int = 8) -> list[dict]:
+    q = query.strip()
+    if len(q) < 2:
+        return []
+    limit = max(1, min(limit, 20))
+    escaped = q.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    pattern = f"%{escaped}%"
+    with get_session() as session:
+        rows = session.scalars(
+            select(Player)
+            .where(Player.full_name.ilike(pattern, escape="\\"))
+            .order_by(Player.current_ranking.asc().nulls_last(), Player.full_name.asc())
+            .limit(limit)
+        )
+        return [
+            {
+                "id": p.id,
+                "name": p.full_name,
+                "country": p.country,
+                "ranking": p.current_ranking,
+            }
+            for p in rows
+        ]
+
+
 def compare_players(player_names: list[str]) -> list[dict]:
     snapshots: list[dict] = []
     for name in player_names:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -28,14 +28,15 @@ export default function App() {
   const [viewMode, setViewMode] = useState('select') // 'select' | 'result'
 
   // ──── Scout handlers ────
-  const onSearch = async () => {
-    if (loading || !playerName.trim()) return
+  const onSearch = async (nameArg) => {
+    const name = (nameArg ?? playerName).trim()
+    if (loading || !name) return
 
     setLoading(true)
     setError('')
 
     try {
-      const response = await fetchPlayerReport(playerName)
+      const response = await fetchPlayerReport(name)
       setData(response)
     } catch (err) {
       setData(null)

--- a/frontend/src/components/PlayerAutocomplete.jsx
+++ b/frontend/src/components/PlayerAutocomplete.jsx
@@ -1,0 +1,187 @@
+import { useEffect, useRef, useState } from 'react'
+import { searchPlayers } from '../utils'
+
+const ACCENTS = {
+  indigo: {
+    ring: 'ring-indigo-400',
+    highlight: 'bg-indigo-500/20 text-indigo-100',
+  },
+  emerald: {
+    ring: 'ring-emerald-400',
+    highlight: 'bg-emerald-500/20 text-emerald-100',
+  },
+}
+
+const MIN_QUERY_LENGTH = 2
+const DEBOUNCE_MS = 200
+
+export default function PlayerAutocomplete({
+  value,
+  onChange,
+  onSelect,
+  onSubmit,
+  placeholder,
+  disabled = false,
+  accent = 'indigo',
+  excludeNames = [],
+}) {
+  const [suggestions, setSuggestions] = useState([])
+  const [open, setOpen] = useState(false)
+  const [loading, setLoading] = useState(false)
+  const [hasSearched, setHasSearched] = useState(false)
+  const [highlight, setHighlight] = useState(-1)
+  const containerRef = useRef(null)
+
+  const accentClasses = ACCENTS[accent] ?? ACCENTS.indigo
+  const excludeSet = new Set(excludeNames.map((n) => n.toLowerCase()))
+  const visibleSuggestions = suggestions.filter(
+    (s) => !excludeSet.has(s.name.toLowerCase()),
+  )
+
+  useEffect(() => {
+    const trimmed = value.trim()
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setSuggestions([])
+      setHasSearched(false)
+      setLoading(false)
+      return undefined
+    }
+
+    const controller = new AbortController()
+    const timer = setTimeout(async () => {
+      setLoading(true)
+      try {
+        const results = await searchPlayers(trimmed, 8, { signal: controller.signal })
+        setSuggestions(results)
+        setHasSearched(true)
+        setHighlight(-1)
+      } catch (err) {
+        if (err?.name !== 'CanceledError' && err?.name !== 'AbortError') {
+          setSuggestions([])
+          setHasSearched(true)
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setLoading(false)
+        }
+      }
+    }, DEBOUNCE_MS)
+
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
+    }
+  }, [value])
+
+  useEffect(() => {
+    const handleClickOutside = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside)
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [])
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setOpen(true)
+      setHighlight((h) => Math.min(h + 1, visibleSuggestions.length - 1))
+      return
+    }
+    if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setHighlight((h) => Math.max(h - 1, 0))
+      return
+    }
+    if (e.key === 'Enter') {
+      if (open && highlight >= 0 && visibleSuggestions[highlight]) {
+        e.preventDefault()
+        handleSelect(visibleSuggestions[highlight])
+        return
+      }
+      setOpen(false)
+      onSubmit?.()
+      return
+    }
+    if (e.key === 'Escape') {
+      setOpen(false)
+      return
+    }
+    if (e.key === 'Tab') {
+      setOpen(false)
+    }
+  }
+
+  const handleSelect = (player) => {
+    onSelect?.(player)
+    setOpen(false)
+    setHighlight(-1)
+  }
+
+  const showDropdown =
+    open &&
+    value.trim().length >= MIN_QUERY_LENGTH &&
+    (loading || visibleSuggestions.length > 0 || hasSearched)
+
+  return (
+    <div ref={containerRef} className="relative w-full">
+      <input
+        className={`w-full rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 outline-none ${accentClasses.ring} placeholder:text-slate-500 focus:ring`}
+        placeholder={placeholder}
+        value={value}
+        disabled={disabled}
+        onChange={(e) => {
+          onChange(e.target.value)
+          setOpen(true)
+        }}
+        onFocus={() => setOpen(true)}
+        onKeyDown={handleKeyDown}
+        autoComplete="off"
+        role="combobox"
+        aria-expanded={showDropdown}
+        aria-autocomplete="list"
+      />
+
+      {showDropdown && (
+        <ul
+          className="absolute z-10 mt-1 max-h-72 w-full overflow-auto rounded-lg border border-slate-700 bg-slate-900 shadow-lg"
+          role="listbox"
+        >
+          {loading && (
+            <li className="px-4 py-2 text-sm text-slate-400">Searching…</li>
+          )}
+          {!loading &&
+            visibleSuggestions.map((player, idx) => {
+              const isHighlighted = idx === highlight
+              return (
+                <li
+                  key={player.id}
+                  role="option"
+                  aria-selected={isHighlighted}
+                  className={`flex cursor-pointer items-center justify-between px-4 py-2 text-sm transition ${
+                    isHighlighted ? accentClasses.highlight : 'text-slate-200 hover:bg-slate-800'
+                  }`}
+                  onMouseEnter={() => setHighlight(idx)}
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    handleSelect(player)
+                  }}
+                >
+                  <span className="font-medium">{player.name}</span>
+                  <span className="text-xs text-slate-400">
+                    {player.ranking != null ? `#${player.ranking}` : 'Unranked'}
+                    {player.country ? ` · ${player.country}` : ''}
+                  </span>
+                </li>
+              )
+            })}
+          {!loading && visibleSuggestions.length === 0 && hasSearched && (
+            <li className="px-4 py-2 text-sm text-slate-400">No players found</li>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/PlayerInput.jsx
+++ b/frontend/src/components/PlayerInput.jsx
@@ -1,18 +1,27 @@
+import PlayerAutocomplete from './PlayerAutocomplete'
+
 export default function PlayerInput({ playerName, onPlayerNameChange, onSearch, loading }) {
   return (
-    <div className="flex flex-col gap-3 sm:flex-row">
-      <input
-        className="w-full rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 outline-none ring-indigo-400 placeholder:text-slate-500 focus:ring"
-        placeholder="e.g. Carlos Alcaraz"
-        value={playerName}
-        onChange={(e) => onPlayerNameChange(e.target.value)}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter' && !loading) onSearch()
-        }}
-      />
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
+      <div className="w-full">
+        <PlayerAutocomplete
+          value={playerName}
+          onChange={onPlayerNameChange}
+          onSelect={(player) => {
+            onPlayerNameChange(player.name)
+            onSearch(player.name)
+          }}
+          onSubmit={() => {
+            if (!loading) onSearch()
+          }}
+          placeholder="e.g. Carlos Alcaraz"
+          accent="indigo"
+          disabled={loading}
+        />
+      </div>
       <button
         className="rounded-lg bg-indigo-500 px-4 py-2 font-medium text-white transition hover:bg-indigo-400 disabled:cursor-not-allowed disabled:opacity-50"
-        onClick={onSearch}
+        onClick={() => onSearch()}
         disabled={loading}
       >
         {loading ? 'Loading...' : 'Generate Report'}

--- a/frontend/src/components/PlayerSelector.jsx
+++ b/frontend/src/components/PlayerSelector.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import PlayerAutocomplete from './PlayerAutocomplete'
 
 export default function PlayerSelector({ selectedPlayers, onAdd, onRemove, onCompare, isLoading }) {
   const [query, setQuery] = useState('')
@@ -24,16 +25,22 @@ export default function PlayerSelector({ selectedPlayers, onAdd, onRemove, onCom
           <label className="mb-1.5 block text-sm font-medium text-slate-400">
             Enter a player name to add ({selectedPlayers.length}/2)
           </label>
-          <div className="flex flex-col gap-2 sm:flex-row">
-            <input
-              className="w-full rounded-lg border border-slate-700 bg-slate-900 px-4 py-2 outline-none ring-emerald-400 placeholder:text-slate-500 focus:ring"
-              placeholder="e.g. Jannik Sinner"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleAdd()
-              }}
-            />
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+            <div className="w-full">
+              <PlayerAutocomplete
+                value={query}
+                onChange={setQuery}
+                onSelect={(player) => {
+                  if (isFull || isAlreadySelected(player.name)) return
+                  onAdd(player.name)
+                  setQuery('')
+                }}
+                onSubmit={handleAdd}
+                placeholder="e.g. Jannik Sinner"
+                accent="emerald"
+                excludeNames={selectedPlayers}
+              />
+            </div>
             <button
               className="rounded-lg bg-emerald-600 px-4 py-2 font-medium text-white transition hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-50"
               onClick={handleAdd}

--- a/frontend/src/utils.js
+++ b/frontend/src/utils.js
@@ -13,3 +13,8 @@ export async function comparePlayers(playerNames) {
   const { data } = await api.post('/compare', { player_names: playerNames })
   return data
 }
+
+export async function searchPlayers(q, limit = 8, { signal } = {}) {
+  const { data } = await api.get('/players/search', { params: { q, limit }, signal })
+  return data.results
+}


### PR DESCRIPTION
Wires both player search inputs to a debounced /players/search endpoint so users can pick a known player from a dropdown instead of guessing exact names. Compare hides already-selected players from suggestions.