### PR TITLE
Cache LLM reports in Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ FastAPI application, domain models, API routes, and service layer.
 	- ORM/data access (`sqlalchemy`, `psycopg`)
 	- config/env handling (`python-dotenv`, `pydantic-settings`)
 	- LLM client (`openai`)
+	- Cache client (`redis`) — optional; used by `cache_service` when `REDIS_URL` is set
 
 #### `backend/__init__.py`
 - Marks `backend` as a package so imports from root are reliable in scripts/tools.
@@ -182,6 +183,7 @@ From `frontend/`:
 2. Set values:
 	- `POSTGRES_URL=postgresql+psycopg://localhost:5432/tennis_scout`
 	- `OPENAI_API_KEY=...` (optional; if omitted the API returns fallback report text)
+	- `REDIS_URL=redis://localhost:6379/0` (optional; enables the LLM response cache — see section below)
 
 ## Database setup
 
@@ -211,3 +213,74 @@ Open `http://localhost:5173`.
 - `GET /player/{name}`
 - `POST /compare`
   - body: `{ "player_names": ["Carlos Alcaraz", "Jannik Sinner"] }`
+- `GET /players/search?q=<query>&limit=<n>`
+  - Autocomplete suggestions for the search inputs; case-insensitive substring match on `full_name`, ordered by `current_ranking`.
+
+## LLM response cache (optional)
+
+`generate_report()` calls OpenAI on every request by default. To cut latency and API spend on repeated lookups (e.g. popular players), the backend can cache LLM responses in Redis. The cache is optional — if `REDIS_URL` is unset or Redis is unreachable, the backend falls through to a direct OpenAI call.
+
+### Enable
+
+1. Install and start Redis:
+	- macOS: `brew install redis && redis-server --daemonize yes`
+	- Docker: `docker run -d -p 6379:6379 redis:7-alpine`
+2. Add to `.env`:
+	```
+	REDIS_URL=redis://localhost:6379/0
+	LLM_CACHE_ENABLED=true          # optional, default true
+	LLM_CACHE_TTL_SECONDS=86400     # optional, default 24h
+	```
+3. Restart the backend. Startup logs should show `Redis cache enabled at redis://localhost:6379/0.`
+
+### Verify it's working
+
+Every report response now includes a `cache` field in its `llm` metadata. Hit the same player twice:
+
+```bash
+curl -s http://localhost:8000/player/Carlos%20Alcaraz | jq '.llm'
+# First call:  "cache": "miss"  (took ~3s)
+curl -s http://localhost:8000/player/Carlos%20Alcaraz | jq '.llm'
+# Second call: "cache": "hit"   (~20ms)
+```
+
+Values:
+- `"hit"` — served from Redis
+- `"miss"` — cache enabled but key wasn't present; written after the LLM call (only on successful responses)
+- `"disabled"` — `REDIS_URL` unset or Redis unreachable; request still succeeds via direct OpenAI
+
+### Inspect what's in the cache
+
+Cache keys are namespaced `llm_report:{model}:{sha256(prompt)}`.
+
+```bash
+# Total keys in the DB
+redis-cli DBSIZE
+
+# List all cached LLM-report keys
+redis-cli --scan --pattern 'llm_report:*'
+
+# Time-to-live of a specific key (seconds remaining)
+redis-cli TTL 'llm_report:gpt-4o-mini:af3bfb518fd8a0...'
+
+# View the cached value (full ReportResult JSON)
+redis-cli GET 'llm_report:gpt-4o-mini:af3bfb518fd8a0...'
+
+# Live monitor of commands hitting Redis (useful when smoke-testing)
+redis-cli MONITOR
+```
+
+### Clear the cache
+
+```bash
+# Delete one entry
+redis-cli DEL 'llm_report:gpt-4o-mini:af3bfb518fd8a0...'
+
+# Delete all cached LLM reports (preserves any other keys)
+redis-cli --scan --pattern 'llm_report:*' | xargs -r redis-cli DEL
+
+# Nuke everything in the current Redis DB
+redis-cli FLUSHDB
+```
+
+Cache keys are **self-invalidating**: the prompt embeds ranking, recent form, and stats, so the SHA-256 changes whenever the underlying data changes — old entries are orphaned and age out via TTL. You should rarely need to flush manually.

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -14,6 +14,9 @@ class Settings(BaseSettings):
     openai_model: str = "gpt-4o-mini"
     tennis_api_key: Optional[str] = None
     tennis_api_host: str = "tennis-api-atp-wta-itf.p.rapidapi.com"
+    redis_url: Optional[str] = None
+    llm_cache_enabled: bool = True
+    llm_cache_ttl_seconds: int = 86400
 
     model_config = SettingsConfigDict(
         env_file=".env",

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,12 +1,22 @@
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
 from app.routes.player_routes import router as player_router
+from app.services.cache_service import ping_cache
 
 settings = get_settings()
 
-app = FastAPI(title=settings.app_name)
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    ping_cache()
+    yield
+
+
+app = FastAPI(title=settings.app_name, lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/services/cache_service.py
+++ b/backend/app/services/cache_service.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+import redis
+
+from app.config import get_settings
+
+settings = get_settings()
+
+_client: Optional[redis.Redis] = None
+_initialized = False
+
+
+def _get_client() -> Optional[redis.Redis]:
+    global _client, _initialized
+    if _initialized:
+        return _client
+
+    _initialized = True
+    if not settings.llm_cache_enabled or not settings.redis_url:
+        return None
+
+    try:
+        _client = redis.Redis.from_url(
+            settings.redis_url,
+            decode_responses=True,
+            socket_timeout=2,
+            socket_connect_timeout=2,
+        )
+    except Exception as e:
+        print(f"Redis client init failed: {e}. Cache disabled for this process.")
+        _client = None
+    return _client
+
+
+def cache_status() -> str:
+    return "enabled" if _get_client() is not None else "disabled"
+
+
+def cache_get_json(key: str) -> Optional[dict]:
+    client = _get_client()
+    if client is None:
+        return None
+    try:
+        raw = client.get(key)
+        if raw is None:
+            return None
+        return json.loads(raw)
+    except Exception as e:
+        print(f"Redis GET failed for key={key!r}: {e}")
+        return None
+
+
+def cache_set_json(key: str, value: dict, ttl_seconds: int) -> None:
+    client = _get_client()
+    if client is None:
+        return
+    try:
+        client.set(key, json.dumps(value), ex=ttl_seconds)
+    except Exception as e:
+        print(f"Redis SET failed for key={key!r}: {e}")
+
+
+def ping_cache() -> bool:
+    client = _get_client()
+    if client is None:
+        print("Redis cache disabled (no REDIS_URL or feature flag off).")
+        return False
+    try:
+        client.ping()
+        print(f"Redis cache enabled at {settings.redis_url}.")
+        return True
+    except Exception as e:
+        print(f"Redis ping failed: {e}. Cache will be skipped at runtime.")
+        return False

--- a/backend/app/services/llm_service.py
+++ b/backend/app/services/llm_service.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 from typing import Literal, TypedDict
 
 from openai import OpenAI
 
 from app.config import get_settings
+from app.services.cache_service import cache_get_json, cache_set_json, cache_status
 
 settings = get_settings()
 
@@ -14,6 +16,7 @@ class LLMMetadata(TypedDict, total=False):
     source: Literal["openai", "fallback"]
     model: str
     error: str
+    cache: Literal["hit", "miss", "disabled"]
 
 
 class ReportResult(TypedDict):
@@ -151,7 +154,21 @@ def _format_h2h_for_prompt(snapshots: list[dict], h2h: dict | None) -> str:
     return "\n".join(parts) + "\n"
 
 
+def _cache_key(prompt: str) -> str:
+    digest = hashlib.sha256(prompt.encode("utf-8")).hexdigest()
+    return f"llm_report:{settings.openai_model}:{digest}"
+
+
 def generate_report(prompt: str) -> ReportResult:
+    cache_enabled = cache_status() == "enabled"
+    key = _cache_key(prompt) if cache_enabled else None
+
+    if cache_enabled:
+        cached = cache_get_json(key)
+        if cached is not None:
+            cached.setdefault("llm", {})["cache"] = "hit"
+            return cached  # type: ignore[return-value]
+
     client = _client()
     if client is None:
         print("LLM client is unavailable. Returning fallback report.")
@@ -162,6 +179,7 @@ def generate_report(prompt: str) -> ReportResult:
                 "source": "fallback",
                 "model": settings.openai_model,
                 "error": "OPENAI_API_KEY is not configured",
+                "cache": "miss" if cache_enabled else "disabled",
             },
         }
 
@@ -183,18 +201,23 @@ def generate_report(prompt: str) -> ReportResult:
                     "source": "fallback",
                     "model": settings.openai_model,
                     "error": "Language model returned empty output",
+                    "cache": "miss" if cache_enabled else "disabled",
                 },
             }
 
         print("LLM response received with status ", response.status)  # Log the beginning of the response
-        return {
+        result: ReportResult = {
             "report": report,
             "llm": {
                 "status": "available",
                 "source": "openai",
                 "model": settings.openai_model,
+                "cache": "miss" if cache_enabled else "disabled",
             },
         }
+        if cache_enabled and key is not None:
+            cache_set_json(key, result, settings.llm_cache_ttl_seconds)
+        return result
     except Exception as e:
         print("Error during LLM request:", e)
         return {
@@ -204,5 +227,6 @@ def generate_report(prompt: str) -> ReportResult:
                 "source": "fallback",
                 "model": settings.openai_model,
                 "error": "Language model request failed",
+                "cache": "miss" if cache_enabled else "disabled",
             },
         }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,3 +6,4 @@ python-dotenv==1.1.0
 openai==1.72.0
 pydantic-settings==2.8.1
 requests==2.32.3
+redis==5.0.8


### PR DESCRIPTION
## Summary
- Wraps `generate_report()` with a Redis-backed cache keyed on `llm_report:{model}:{sha256(prompt)}`. The prompt embeds every variable the LLM sees (ranking, stats, recent form, surface split, H2H), so the cache **self-invalidates** when data changes — no eviction logic needed.
- Only successful LLM responses are cached (status `available`). Fallback / error responses are returned as-is so transient OpenAI outages don't poison the cache.
- Adds a `cache` field to the `llm` metadata block (`hit` / `miss` / `disabled`) for easy hit-rate inspection.
- Graceful degrade: if `REDIS_URL` is unset or Redis is unreachable, requests fall through to a direct OpenAI call. Cache outages never break a request.
- New env vars (all optional): `REDIS_URL`, `LLM_CACHE_ENABLED` (default `true`), `LLM_CACHE_TTL_SECONDS` (default `86400`).
- Routes (`/player/{name}`, `/compare`) are untouched — caching is invisible to them.

## Performance
<img width="539" height="226" alt="image" src="https://github.com/user-attachments/assets/dddbcae1-e265-4ba3-906c-62ed3b631a98" />

## Test plan
Verified end-to-end against a local `redis-server`:

- [x] `/player/Carlos Alcaraz` cold → `cache: "miss"`, ~3s (OpenAI call)
- [x] `/player/Carlos Alcaraz` warm → `cache: "hit"`, **22ms**
- [x] `/compare` cold → `cache: "miss"`, ~36s
- [x] `/compare` warm → `cache: "hit"`, **39ms** (~900× faster)
- [x] Redis shut down mid-flight → request succeeds via direct OpenAI, no error surfaced
- [x] `REDIS_URL` unset → `cache: "disabled"`, requests succeed
- [x] Redis key format confirmed: `llm_report:gpt-4o-mini:<sha256>` with TTL ~86400s
- [ ] Self-invalidation on data change (bump `current_ranking` in DB, re-request → expect miss)
- [ ] Confirm fallback responses (e.g. OpenAI key unset) are *not* written to Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)