### PR TITLE
Add player photos from Wikimedia Commons

### DIFF
--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -48,6 +48,7 @@ class Player(Base):
     pro_since: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     current_ranking: Mapped[Optional[int]] = mapped_column(Integer, nullable=True)
     coach: Mapped[Optional[str]] = mapped_column(String(120), nullable=True)
+    image_url: Mapped[Optional[str]] = mapped_column(Text, nullable=True)
 
     # Relationships
     matches_as_p1: Mapped[list["Match"]] = relationship(

--- a/backend/app/services/data_service.py
+++ b/backend/app/services/data_service.py
@@ -178,6 +178,7 @@ def _build_snapshot(player: Player, matches: list[Match], session: Session) -> d
             "weight_kg": player.weight_kg,
             "pro_since": player.pro_since,
             "birthdate": player.birthdate.isoformat() if player.birthdate else None,
+            "image_url": player.image_url,
         },
         "stats": _summarize_matches(matches, player.id, per_match_stats),
     }

--- a/data/backfill_player_photos.py
+++ b/data/backfill_player_photos.py
@@ -1,0 +1,134 @@
+"""Backfill players.image_url from Wikipedia thumbnails.
+
+For every player without an image_url, search Wikipedia for "{full_name} tennis",
+take the top hit, and store the page's main thumbnail.
+
+Idempotent: re-running only touches rows where image_url IS NULL.
+
+Usage:
+    .venv/bin/python data/backfill_player_photos.py
+    .venv/bin/python data/backfill_player_photos.py --limit 20   # spot-check
+    .venv/bin/python data/backfill_player_photos.py --refresh    # also refresh non-null rows
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+import time
+from pathlib import Path
+from typing import Optional
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1] / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+import requests
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from app.db import SessionLocal
+from app.models import Player
+
+WIKI_API = "https://en.wikipedia.org/w/api.php"
+USER_AGENT = "tennis-scout-agent/1.0 (https://github.com/linbeau0822/tennis-scout-agent)"
+THUMB_SIZE = 400
+SLEEP_BETWEEN_PLAYERS = 0.5
+
+session = requests.Session()
+session.headers.update({"User-Agent": USER_AGENT})
+
+
+def _wiki_search_title(player_name: str) -> Optional[str]:
+    params = {
+        "action": "query",
+        "list": "search",
+        "srsearch": f"{player_name} tennis",
+        "srlimit": 1,
+        "format": "json",
+    }
+    resp = session.get(WIKI_API, params=params, timeout=10)
+    resp.raise_for_status()
+    hits = resp.json().get("query", {}).get("search", [])
+    if not hits:
+        return None
+    return hits[0]["title"]
+
+
+def _wiki_thumbnail_for_title(title: str) -> Optional[str]:
+    params = {
+        "action": "query",
+        "titles": title,
+        "prop": "pageimages",
+        "piprop": "thumbnail",
+        "pithumbsize": THUMB_SIZE,
+        "format": "json",
+        "redirects": 1,
+    }
+    resp = session.get(WIKI_API, params=params, timeout=10)
+    resp.raise_for_status()
+    pages = resp.json().get("query", {}).get("pages", {})
+    for page in pages.values():
+        thumb = page.get("thumbnail", {}).get("source")
+        if thumb:
+            return thumb
+    return None
+
+
+def find_photo(player_name: str) -> Optional[str]:
+    title = _wiki_search_title(player_name)
+    if not title:
+        return None
+    return _wiki_thumbnail_for_title(title)
+
+
+def backfill(session_db: Session, limit: Optional[int], refresh: bool) -> tuple[int, int, int]:
+    stmt = select(Player)
+    if not refresh:
+        stmt = stmt.where(Player.image_url.is_(None))
+    stmt = stmt.order_by(Player.current_ranking.asc().nulls_last(), Player.full_name.asc())
+    if limit is not None:
+        stmt = stmt.limit(limit)
+
+    players = list(session_db.scalars(stmt))
+    total = len(players)
+    print(f"Targeting {total} player(s).")
+
+    filled = skipped = errored = 0
+    for idx, player in enumerate(players, start=1):
+        try:
+            url = find_photo(player.full_name)
+        except Exception as exc:
+            errored += 1
+            print(f"[{idx}/{total}] ERROR {player.full_name}: {exc}")
+            time.sleep(SLEEP_BETWEEN_PLAYERS)
+            continue
+
+        if url:
+            player.image_url = url
+            session_db.commit()
+            filled += 1
+            print(f"[{idx}/{total}] OK    {player.full_name} -> {url[:80]}...")
+        else:
+            skipped += 1
+            print(f"[{idx}/{total}] MISS  {player.full_name}")
+
+        time.sleep(SLEEP_BETWEEN_PLAYERS)
+
+    return filled, skipped, errored
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--limit", type=int, default=None, help="Only process N players.")
+    parser.add_argument("--refresh", action="store_true", help="Also overwrite rows that already have image_url.")
+    args = parser.parse_args()
+
+    with SessionLocal() as db:
+        filled, skipped, errored = backfill(db, args.limit, args.refresh)
+
+    print()
+    print(f"Done. Filled {filled}, missed {skipped}, errored {errored}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/migrate_add_image_url.py
+++ b/data/migrate_add_image_url.py
@@ -1,0 +1,30 @@
+"""One-shot migration: add the players.image_url column.
+
+Run once after pulling the player-photos branch:
+
+    .venv/bin/python data/migrate_add_image_url.py
+
+Safe to re-run thanks to `IF NOT EXISTS`.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1] / "backend"
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from sqlalchemy import text
+
+from app.db import engine
+
+
+def main() -> None:
+    with engine.begin() as conn:
+        conn.execute(text("ALTER TABLE players ADD COLUMN IF NOT EXISTS image_url TEXT"))
+        print("OK: players.image_url is present.")
+
+
+if __name__ == "__main__":
+    main()

--- a/frontend/src/components/ComparisonView.jsx
+++ b/frontend/src/components/ComparisonView.jsx
@@ -1,4 +1,5 @@
 import ReactMarkdown from 'react-markdown'
+import PlayerPhoto from './PlayerPhoto'
 
 export default function ComparisonView({ data, onBack }) {
   if (!data) return null
@@ -21,12 +22,18 @@ export default function ComparisonView({ data, onBack }) {
 
       {/* Player Overview – side by side */}
       <div className="grid gap-4 md:grid-cols-2">
-        {players.map((player, idx) => (
+        {players.map((player) => (
           <div
             key={player.id}
-            className="rounded-xl border border-slate-800 bg-slate-900/60 p-5 text-center"
+            className="flex flex-col items-center rounded-xl border border-slate-800 bg-slate-900/60 p-5 text-center"
           >
-            <h3 className="text-lg font-bold">{player.name}</h3>
+            <PlayerPhoto
+              imageUrl={player.image_url}
+              name={player.name}
+              size="lg"
+              accent="emerald"
+            />
+            <h3 className="mt-3 text-lg font-bold">{player.name}</h3>
             <p className="mt-1 text-sm text-slate-400">
               {player.ranking ? `Rank #${player.ranking} • ` : ''}{player.country || 'N/A'}
             </p>

--- a/frontend/src/components/PlayerPhoto.jsx
+++ b/frontend/src/components/PlayerPhoto.jsx
@@ -1,0 +1,52 @@
+import { useState, useEffect } from 'react'
+
+const SIZE_CLASSES = {
+  md: 'h-14 w-14 text-base',
+  lg: 'h-20 w-20 text-xl',
+}
+
+const ACCENT_RINGS = {
+  indigo: 'ring-indigo-400/40',
+  emerald: 'ring-emerald-400/40',
+  slate: 'ring-slate-700',
+}
+
+function getInitials(name) {
+  if (!name) return '?'
+  const parts = name.trim().split(/\s+/)
+  if (parts.length === 1) return parts[0][0].toUpperCase()
+  return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+}
+
+export default function PlayerPhoto({ imageUrl, name, size = 'md', accent = 'slate' }) {
+  const [errored, setErrored] = useState(false)
+  const sizeClass = SIZE_CLASSES[size] ?? SIZE_CLASSES.md
+  const ringClass = ACCENT_RINGS[accent] ?? ACCENT_RINGS.slate
+
+  useEffect(() => {
+    setErrored(false)
+  }, [imageUrl])
+
+  const showImage = imageUrl && !errored
+
+  if (showImage) {
+    return (
+      <img
+        src={imageUrl}
+        alt={name || 'Player'}
+        loading="lazy"
+        onError={() => setErrored(true)}
+        className={`${sizeClass} shrink-0 rounded-full object-cover ring-2 ${ringClass} bg-slate-800`}
+      />
+    )
+  }
+
+  return (
+    <div
+      className={`${sizeClass} flex shrink-0 items-center justify-center rounded-full bg-slate-800 font-semibold text-slate-300 ring-2 ${ringClass}`}
+      aria-label={name || 'Player'}
+    >
+      {getInitials(name)}
+    </div>
+  )
+}

--- a/frontend/src/components/StatsTable.jsx
+++ b/frontend/src/components/StatsTable.jsx
@@ -1,14 +1,19 @@
+import PlayerPhoto from './PlayerPhoto'
+
 export default function StatsTable({ snapshot }) {
   const { player, stats } = snapshot
 
   return (
     <div className="overflow-hidden rounded-xl border border-slate-800 bg-slate-900/60">
-      <div className="border-b border-slate-800 p-4">
-        <h2 className="text-xl font-semibold">{player.name}</h2>
-        <p className="text-sm text-slate-400">
-          {player.ranking ? `Rank #${player.ranking} • ` : ''}{player.country || 'N/A'}
-          {player.handedness ? ` • ${player.handedness}` : ''}
-        </p>
+      <div className="flex items-center gap-4 border-b border-slate-800 p-4">
+        <PlayerPhoto imageUrl={player.image_url} name={player.name} size="lg" accent="indigo" />
+        <div>
+          <h2 className="text-xl font-semibold">{player.name}</h2>
+          <p className="text-sm text-slate-400">
+            {player.ranking ? `Rank #${player.ranking} • ` : ''}{player.country || 'N/A'}
+            {player.handedness ? ` • ${player.handedness}` : ''}
+          </p>
+        </div>
       </div>
 
       <div className="grid gap-4 p-4 sm:grid-cols-2 lg:grid-cols-4">


### PR DESCRIPTION
## Summary
Adds player portraits to the Scout Report and Compare Players tabs, sourced from Wikipedia's free `pageimages` API instead of self-hosted storage.

**Why Wikimedia over S3** — the ATP API the project already uses doesn't return photo URLs, so S3 wouldn't replace an existing source (it would just add new cloud infra). Wikimedia is the canonical source for properly-licensed sports photos, the URLs are stable, and the MediaWiki API is free and unauthenticated. Schema-wise the column is the same (`Player.image_url TEXT`) — only the *source* differs, so S3 stays an option later without breaking changes.

**Backend**
- `Player.image_url` nullable column added to the model
- `data/migrate_add_image_url.py` — idempotent `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` script (no Alembic in this project)
- `data/backfill_player_photos.py` — searches Wikipedia for `"{name} tennis"`, takes the top hit's `pageimages` thumbnail (400px), stores the URL. Polite 0.5s delay between requests, idempotent skip of already-filled rows, `--limit` and `--refresh` flags. User-Agent set per Wikipedia's policy.
- `data_service._build_snapshot()` now includes `image_url` in the player dict — flows through to both `/player/{name}` and `/compare` automatically; no route changes.

**Frontend**
- `PlayerPhoto.jsx` — shared circular photo component. Renders the Commons image with `loading="lazy"`, falls back to initials in a slate-background circle when `image_url` is null *or* the `<img>` errors at runtime. Accepts `size` (`md`/`lg`) and `accent` (`indigo`/`emerald`) to match the existing tab theming.
- `StatsTable.jsx` — large portrait (80px) in the Scout Report header, indigo ring.
- `ComparisonView.jsx` — large portrait atop each player column in the Compare grid, emerald ring.

## Test plan
- [x] Migration applied: `players.image_url` column present.
- [x] Backfill ran on top 200 ranked players: **177/200 ranked filled (88.5% hit rate), 0 errors**. Tail-of-rankings misses (e.g. Aaron Schmid) have no Wikipedia entry — expected.
- [x] `GET /player/Carlos Alcaraz` returns a `upload.wikimedia.org` URL in `player.image_url`.
- [x] `POST /compare` returns URLs for both players.
- [x] Backfill script is idempotent (re-run skips already-filled rows).
- [ ] Browser: search a top player on the Scout tab → photo renders next to name.
- [ ] Browser: compare two top players → both portraits render side-by-side at the top.
- [ ] Browser: search an unranked obscure player → initials fallback renders cleanly (no broken-image icon).

## Follow-ups (out of scope)
- Long-tail backfill — script can re-run later for the ~4k unranked historical opponents; hit rate will be low and bandwidth is the main cost.
- Hook the Wikipedia lookup into `fetch_player_profile()` so new players get auto-backfilled at runtime (currently the backfill is a one-shot script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)