### PR TITLE
Highlight Prediction section in Compare LLM output

### DIFF
--- a/frontend/src/components/ComparisonView.jsx
+++ b/frontend/src/components/ComparisonView.jsx
@@ -242,7 +242,14 @@ function StatsComparison({ snapshots }) {
 
 /* ───────────── AI Analysis + Prediction ───────────── */
 
+const PREDICTION_HEADING = /^##\s+Prediction\b.*$/im
+
 function AnalysisSection({ report, llm, isUnavailable }) {
+  const match = !isUnavailable && report ? report.match(PREDICTION_HEADING) : null
+  const splitIdx = match ? match.index : -1
+  const mainContent = splitIdx >= 0 ? report.slice(0, splitIdx).trimEnd() : report
+  const predictionContent = splitIdx >= 0 ? report.slice(splitIdx).trim() : null
+
   return (
     <article className="rounded-xl border border-slate-800 bg-slate-900/60 p-4">
       <div className="flex items-center justify-between gap-3">
@@ -281,7 +288,35 @@ function AnalysisSection({ report, llm, isUnavailable }) {
               strong: ({ node, ...props }) => <strong className="font-semibold text-slate-100" {...props} />,
             }}
           >
-            {report}
+            {mainContent}
+          </ReactMarkdown>
+        </div>
+      )}
+
+      {!isUnavailable && predictionContent && (
+        <div
+          style={{ backgroundColor: '#F7E7CE' }}
+          className="prose mt-4 max-w-none rounded-xl border border-amber-200/40 p-5 text-sm leading-relaxed text-slate-900"
+        >
+          <ReactMarkdown
+            components={{
+              h2: ({ node, ...props }) => (
+                <h2 className="mb-3 mt-0 text-xl font-bold text-slate-900" {...props} />
+              ),
+              h3: ({ node, ...props }) => (
+                <h3 className="mb-2 mt-3 text-base font-semibold text-slate-900" {...props} />
+              ),
+              p: ({ node, ...props }) => <p className="mb-2 text-slate-800" {...props} />,
+              ul: ({ node, ...props }) => (
+                <ul className="mb-2 ml-4 list-disc text-slate-800" {...props} />
+              ),
+              li: ({ node, ...props }) => <li className="mb-1" {...props} />,
+              strong: ({ node, ...props }) => (
+                <strong className="font-semibold text-slate-900" {...props} />
+              ),
+            }}
+          >
+            {predictionContent}
           </ReactMarkdown>
         </div>
       )}


### PR DESCRIPTION
## Summary
The Compare Players tab's LLM output renders five sections in one navy panel, which buries the **Prediction** — the section the user actually came for. This change splits the report at the `## Prediction` heading and renders the final section in a champagne (#F7E7CE) callout with dark text, so the predicted winner is visually pronounced.

**How it works**
- `AnalysisSection` (in `ComparisonView.jsx`) regex-splits the markdown at `^##\s+Prediction\b`.
- Everything before the heading renders in the existing navy block with the existing typography overrides.
- The Prediction heading + body render in a new cream container below, with `text-slate-900` / `text-slate-800` for legibility (~14:1 contrast vs #F7E7CE — clears WCAG AA).
- If the LLM omits the `## Prediction` heading (off-script response, fallback text, etc.) the whole report renders on navy as before — no regression.
- The `isUnavailable` branch is untouched.

Single-file change. No backend, API, or dependency changes.

## Test plan
- [x] Cached LLM output for Alcaraz vs Sinner contains `## Prediction` at offset 1977 with 468 chars after — split logic triggers.
- [x] Frontend dev server still compiles (no syntax errors).
- [ ] Browser: compare two players → first four sections sit on navy, Prediction section sits in champagne callout with dark text.
- [ ] DevTools: confirm inline `background-color: #F7E7CE` on the prediction container.
- [ ] Force LLM unavailable → existing amber "LLM unavailable" message renders, no cream box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)